### PR TITLE
Implement vectors

### DIFF
--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -11,10 +11,11 @@ use crate::env::procedures::{
     is_boolean, is_char, is_char_alphabetic, is_char_lowercase, is_char_numeric, is_char_uppercase,
     is_char_whitespace, is_complex, is_even, is_exact, is_exact_integer, is_inexact, is_integer,
     is_list, is_number, is_odd, is_pair, is_procedure, is_rational, is_real, is_string, is_symbol,
-    is_vector, list_append, list_length, list_reverse, load_file, make_vector, max, min, modulo,
-    mult, new_list, new_string, new_vector, newline, not, num_to_string, or, pretty_print, print,
-    println, str_append, str_length, string_to_downcase, string_to_list, string_to_num,
-    string_to_symbol, string_to_upcase, sub, symbol_to_string, vector_len,
+    is_vector, list_append, list_length, list_reverse, list_to_vector, load_file, make_vector, max,
+    min, modulo, mult, new_list, new_string, new_vector, newline, not, num_to_string, or,
+    pretty_print, print, println, str_append, str_length, string_to_downcase, string_to_list,
+    string_to_num, string_to_symbol, string_to_upcase, string_to_vector, sub, symbol_to_string,
+    vector_len, vector_ref, vector_set, vector_to_list, vector_to_string,
 };
 use crate::macros::{quote, set_car, set_cdr};
 use crate::types::Expr;
@@ -85,6 +86,8 @@ impl Env {
         data.insert("vector".to_string(), Expr::Procedure(new_vector));
         data.insert("make-vector".to_string(), Expr::Procedure(make_vector));
         data.insert("vector-length".to_string(), Expr::Procedure(vector_len));
+        data.insert("vector-ref".to_string(), Expr::Procedure(vector_ref));
+        data.insert("vector-set!".to_string(), Expr::Procedure(vector_set));
         // Conversions
         data.insert("number->string".to_string(), Expr::Procedure(num_to_string));
         data.insert(
@@ -97,6 +100,16 @@ impl Env {
             Expr::Procedure(string_to_symbol),
         );
         data.insert("string->list".to_string(), Expr::Procedure(string_to_list));
+        data.insert(
+            "string->vector".to_string(),
+            Expr::Procedure(string_to_vector),
+        );
+        data.insert("list->vector".to_string(), Expr::Procedure(list_to_vector));
+        data.insert("vector->list".to_string(), Expr::Procedure(vector_to_list));
+        data.insert(
+            "vector->string".to_string(),
+            Expr::Procedure(vector_to_string),
+        );
         // Predicates
         data.insert("number?".to_string(), Expr::Procedure(is_number));
         data.insert("real?".to_string(), Expr::Procedure(is_real));

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -15,7 +15,8 @@ use crate::env::procedures::{
     make_vector, max, min, modulo, mult, new_list, new_string, new_vector, newline, not,
     num_to_string, or, pretty_print, print, println, str_append, str_length, string_to_downcase,
     string_to_list, string_to_num, string_to_symbol, string_to_upcase, string_to_vector, sub,
-    symbol_to_string, vector_len, vector_ref, vector_set, vector_to_list, vector_to_string,
+    symbol_to_string, vector_append, vector_copy, vector_fill, vector_len, vector_ref, vector_set,
+    vector_to_list, vector_to_string,
 };
 use crate::macros::{quote, set_car, set_cdr};
 use crate::types::{Expr, Procedure};
@@ -90,9 +91,12 @@ impl Env {
             // Vectors
             env.insert_proc("vector", new_vector);
             env.insert_proc("make-vector", make_vector);
-            env.insert_proc("vector-length", vector_len);
             env.insert_proc("vector-ref", vector_ref);
             env.insert_proc("vector-set!", vector_set);
+            env.insert_proc("vector-length", vector_len);
+            env.insert_proc("vector-copy", vector_copy);
+            env.insert_proc("vector-fill!", vector_fill);
+            env.insert_proc("vector-append", vector_append);
             // Conversions
             env.insert_proc("number->string", num_to_string);
             env.insert_proc("symbol->string", symbol_to_string);

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -11,11 +11,11 @@ use crate::env::procedures::{
     is_boolean, is_char, is_char_alphabetic, is_char_lowercase, is_char_numeric, is_char_uppercase,
     is_char_whitespace, is_complex, is_even, is_exact, is_exact_integer, is_inexact, is_integer,
     is_list, is_number, is_odd, is_pair, is_procedure, is_rational, is_real, is_string, is_symbol,
-    is_vector, list_append, list_length, list_reverse, list_to_vector, load_file, make_vector, max,
-    min, modulo, mult, new_list, new_string, new_vector, newline, not, num_to_string, or,
-    pretty_print, print, println, str_append, str_length, string_to_downcase, string_to_list,
-    string_to_num, string_to_symbol, string_to_upcase, string_to_vector, sub, symbol_to_string,
-    vector_len, vector_ref, vector_set, vector_to_list, vector_to_string,
+    is_vector, list_append, list_length, list_reverse, list_to_string, list_to_vector, load_file,
+    make_vector, max, min, modulo, mult, new_list, new_string, new_vector, newline, not,
+    num_to_string, or, pretty_print, print, println, str_append, str_length, string_to_downcase,
+    string_to_list, string_to_num, string_to_symbol, string_to_upcase, string_to_vector, sub,
+    symbol_to_string, vector_len, vector_ref, vector_set, vector_to_list, vector_to_string,
 };
 use crate::macros::{quote, set_car, set_cdr};
 use crate::types::Expr;
@@ -104,6 +104,7 @@ impl Env {
             "string->vector".to_string(),
             Expr::Procedure(string_to_vector),
         );
+        data.insert("list->string".to_string(), Expr::Procedure(list_to_string));
         data.insert("list->vector".to_string(), Expr::Procedure(list_to_vector));
         data.insert("vector->list".to_string(), Expr::Procedure(vector_to_list));
         data.insert(

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -18,7 +18,7 @@ use crate::env::procedures::{
     symbol_to_string, vector_len, vector_ref, vector_set, vector_to_list, vector_to_string,
 };
 use crate::macros::{quote, set_car, set_cdr};
-use crate::types::Expr;
+use crate::types::{Expr, Procedure};
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -34,130 +34,105 @@ pub struct Env {
 }
 
 impl Env {
-    pub fn standard_env() -> EnvRef {
-        let mut data: HashMap<String, Expr> = HashMap::new();
-        // IO
-        data.insert("load".to_string(), Expr::Procedure(load_file));
-        data.insert("display".to_string(), Expr::Procedure(display));
-        data.insert("newline".to_string(), Expr::Procedure(newline));
-        data.insert("print".to_string(), Expr::Procedure(print));
-        data.insert("println".to_string(), Expr::Procedure(println));
-        data.insert("pp".to_string(), Expr::Procedure(pretty_print));
-        // Math
-        data.insert("+".to_string(), Expr::Procedure(add));
-        data.insert("-".to_string(), Expr::Procedure(sub));
-        data.insert("*".to_string(), Expr::Procedure(mult));
-        data.insert("/".to_string(), Expr::Procedure(div));
-        data.insert("modulo".to_string(), Expr::Procedure(modulo));
-        data.insert("expt".to_string(), Expr::Procedure(exponent));
-        data.insert("abs".to_string(), Expr::Procedure(abs));
-        data.insert("ceiling".to_string(), Expr::Procedure(ceil));
-        data.insert("floor".to_string(), Expr::Procedure(floor));
-        data.insert("min".to_string(), Expr::Procedure(min));
-        data.insert("max".to_string(), Expr::Procedure(max));
-        // Strings
-        data.insert("string".to_string(), Expr::Procedure(new_string));
-        data.insert("string-append".to_string(), Expr::Procedure(str_append));
-        data.insert("string-length".to_string(), Expr::Procedure(str_length));
-        data.insert(
-            "string-upcase".to_string(),
-            Expr::Procedure(string_to_upcase),
-        );
-        data.insert(
-            "string-downcase".to_string(),
-            Expr::Procedure(string_to_downcase),
-        );
-        // Booleans
-        data.insert("not".to_string(), Expr::Procedure(not));
-        data.insert("and".to_string(), Expr::Procedure(and));
-        data.insert("or".to_string(), Expr::Procedure(or));
-        // Lists & Pairs
-        data.insert("cons".to_string(), Expr::Procedure(cons_proc));
-        data.insert("list".to_string(), Expr::Procedure(new_list));
-        data.insert("append".to_string(), Expr::Procedure(list_append));
-        data.insert("length".to_string(), Expr::Procedure(list_length));
-        data.insert("car".to_string(), Expr::Procedure(car));
-        data.insert("cdr".to_string(), Expr::Procedure(cdr));
-        data.insert("cadr".to_string(), Expr::Procedure(cadr));
-        data.insert("set-car!".to_string(), Expr::Procedure(set_car));
-        data.insert("set-cdr!".to_string(), Expr::Procedure(set_cdr));
-        data.insert("reverse".to_string(), Expr::Procedure(list_reverse));
-        // Vectors
-        data.insert("vector".to_string(), Expr::Procedure(new_vector));
-        data.insert("make-vector".to_string(), Expr::Procedure(make_vector));
-        data.insert("vector-length".to_string(), Expr::Procedure(vector_len));
-        data.insert("vector-ref".to_string(), Expr::Procedure(vector_ref));
-        data.insert("vector-set!".to_string(), Expr::Procedure(vector_set));
-        // Conversions
-        data.insert("number->string".to_string(), Expr::Procedure(num_to_string));
-        data.insert(
-            "symbol->string".to_string(),
-            Expr::Procedure(symbol_to_string),
-        );
-        data.insert("string->number".to_string(), Expr::Procedure(string_to_num));
-        data.insert(
-            "string->symbol".to_string(),
-            Expr::Procedure(string_to_symbol),
-        );
-        data.insert("string->list".to_string(), Expr::Procedure(string_to_list));
-        data.insert(
-            "string->vector".to_string(),
-            Expr::Procedure(string_to_vector),
-        );
-        data.insert("list->string".to_string(), Expr::Procedure(list_to_string));
-        data.insert("list->vector".to_string(), Expr::Procedure(list_to_vector));
-        data.insert("vector->list".to_string(), Expr::Procedure(vector_to_list));
-        data.insert(
-            "vector->string".to_string(),
-            Expr::Procedure(vector_to_string),
-        );
-        // Predicates
-        data.insert("number?".to_string(), Expr::Procedure(is_number));
-        data.insert("real?".to_string(), Expr::Procedure(is_real));
-        data.insert("rational?".to_string(), Expr::Procedure(is_rational));
-        data.insert("complex?".to_string(), Expr::Procedure(is_complex));
-        data.insert("integer?".to_string(), Expr::Procedure(is_integer));
-        data.insert("even?".to_string(), Expr::Procedure(is_even));
-        data.insert("odd?".to_string(), Expr::Procedure(is_odd));
-        data.insert("exact?".to_string(), Expr::Procedure(is_exact));
-        data.insert("inexact?".to_string(), Expr::Procedure(is_inexact));
-        data.insert(
-            "exact-integer?".to_string(),
-            Expr::Procedure(is_exact_integer),
-        );
-        data.insert("symbol?".to_string(), Expr::Procedure(is_symbol));
-        data.insert("string?".to_string(), Expr::Procedure(is_string));
-        data.insert("char?".to_string(), Expr::Procedure(is_char));
-        data.insert(
-            "char-alphabetic?".to_string(),
-            Expr::Procedure(is_char_alphabetic),
-        );
-        data.insert(
-            "char-numeric?".to_string(),
-            Expr::Procedure(is_char_numeric),
-        );
-        data.insert(
-            "char-whitespace?".to_string(),
-            Expr::Procedure(is_char_whitespace),
-        );
-        data.insert(
-            "char-upper-case?".to_string(),
-            Expr::Procedure(is_char_uppercase),
-        );
-        data.insert(
-            "char-lower-case?".to_string(),
-            Expr::Procedure(is_char_lowercase),
-        );
-        data.insert("boolean?".to_string(), Expr::Procedure(is_boolean));
-        data.insert("list?".to_string(), Expr::Procedure(is_list));
-        data.insert("pair?".to_string(), Expr::Procedure(is_pair));
-        data.insert("vector?".to_string(), Expr::Procedure(is_vector));
-        data.insert("procedure?".to_string(), Expr::Procedure(is_procedure));
-        // Misc
-        data.insert("exit".to_string(), Expr::Procedure(exit));
-        data.insert("quote".to_string(), Expr::Procedure(quote));
+    pub fn new() -> EnvRef {
+        let map: HashMap<String, Expr> = HashMap::new();
+        Rc::new(RefCell::new(Env {
+            data: map,
+            outer: None,
+        }))
+    }
 
-        Rc::new(RefCell::new(Env { data, outer: None }))
+    pub fn standard_env() -> EnvRef {
+        let env_ref = Env::new();
+        {
+            let mut env = env_ref.borrow_mut();
+            // IO
+            env.insert_proc("load", load_file);
+            env.insert_proc("load", load_file);
+            env.insert_proc("display", display);
+            env.insert_proc("newline", newline);
+            env.insert_proc("print", print);
+            env.insert_proc("println", println);
+            env.insert_proc("pp", pretty_print);
+            // Math
+            env.insert_proc("+", add);
+            env.insert_proc("-", sub);
+            env.insert_proc("*", mult);
+            env.insert_proc("/", div);
+            env.insert_proc("modulo", modulo);
+            env.insert_proc("expt", exponent);
+            env.insert_proc("abs", abs);
+            env.insert_proc("ceiling", ceil);
+            env.insert_proc("floor", floor);
+            env.insert_proc("min", min);
+            env.insert_proc("max", max);
+            // Strings
+            env.insert_proc("string", new_string);
+            env.insert_proc("string-append", str_append);
+            env.insert_proc("string-length", str_length);
+            env.insert_proc("string-upcase", string_to_upcase);
+            env.insert_proc("string-downcase", string_to_downcase);
+            // Booleans
+            env.insert_proc("not", not);
+            env.insert_proc("and", and);
+            env.insert_proc("or", or);
+            // Lists & Pairs
+            env.insert_proc("cons", cons_proc);
+            env.insert_proc("list", new_list);
+            env.insert_proc("append", list_append);
+            env.insert_proc("length", list_length);
+            env.insert_proc("car", car);
+            env.insert_proc("cdr", cdr);
+            env.insert_proc("cadr", cadr);
+            env.insert_proc("set-car!", set_car);
+            env.insert_proc("set-cdr!", set_cdr);
+            env.insert_proc("reverse", list_reverse);
+            // Vectors
+            env.insert_proc("vector", new_vector);
+            env.insert_proc("make-vector", make_vector);
+            env.insert_proc("vector-length", vector_len);
+            env.insert_proc("vector-ref", vector_ref);
+            env.insert_proc("vector-set!", vector_set);
+            // Conversions
+            env.insert_proc("number->string", num_to_string);
+            env.insert_proc("symbol->string", symbol_to_string);
+            env.insert_proc("string->number", string_to_num);
+            env.insert_proc("string->symbol", string_to_symbol);
+            env.insert_proc("string->list", string_to_list);
+            env.insert_proc("string->vector", string_to_vector);
+            env.insert_proc("list->string", list_to_string);
+            env.insert_proc("list->vector", list_to_vector);
+            env.insert_proc("vector->list", vector_to_list);
+            env.insert_proc("vector->string", vector_to_string);
+            // Predicates
+            env.insert_proc("number?", is_number);
+            env.insert_proc("real?", is_real);
+            env.insert_proc("rational?", is_rational);
+            env.insert_proc("complex?", is_complex);
+            env.insert_proc("integer?", is_integer);
+            env.insert_proc("even?", is_even);
+            env.insert_proc("odd?", is_odd);
+            env.insert_proc("exact?", is_exact);
+            env.insert_proc("inexact?", is_inexact);
+            env.insert_proc("exact-integer?", is_exact_integer);
+            env.insert_proc("symbol?", is_symbol);
+            env.insert_proc("string?", is_string);
+            env.insert_proc("char?", is_char);
+            env.insert_proc("char-alphabetic?", is_char_alphabetic);
+            env.insert_proc("char-numeric?", is_char_numeric);
+            env.insert_proc("char-whitespace?", is_char_whitespace);
+            env.insert_proc("char-upper-case?", is_char_uppercase);
+            env.insert_proc("char-lower-case?", is_char_lowercase);
+            env.insert_proc("boolean?", is_boolean);
+            env.insert_proc("list?", is_list);
+            env.insert_proc("pair?", is_pair);
+            env.insert_proc("vector?", is_vector);
+            env.insert_proc("procedure?", is_procedure);
+            // Misc
+            env.insert_proc("exit", exit);
+            env.insert_proc("quote", quote);
+        }
+        env_ref
     }
 
     /// Initialize an empty environment.
@@ -177,5 +152,16 @@ impl Env {
         } else {
             None
         }
+    }
+
+    /// Insert a new `Procedure` into `HashMap<String, Expr>`. Only used to clean up boilerplate in `env::standard_env()`.
+    fn insert_proc(&mut self, name: &str, function: Procedure) {
+        self.data
+            .insert(name.to_string(), Expr::Procedure(function));
+    }
+
+    /// Insert a new `Expr` into `&self`.
+    pub fn insert_expr(&mut self, name: &str, value: Expr) {
+        self.data.insert(name.to_string(), value);
     }
 }

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -11,10 +11,10 @@ use crate::env::procedures::{
     is_boolean, is_char, is_char_alphabetic, is_char_lowercase, is_char_numeric, is_char_uppercase,
     is_char_whitespace, is_complex, is_even, is_exact, is_exact_integer, is_inexact, is_integer,
     is_list, is_number, is_odd, is_pair, is_procedure, is_rational, is_real, is_string, is_symbol,
-    list_append, list_length, list_reverse, load_file, max, min, modulo, mult, new_list,
-    new_string, newline, not, num_to_string, or, pretty_print, print, println, str_append,
-    str_length, string_to_downcase, string_to_list, string_to_num, string_to_symbol,
-    string_to_upcase, sub, symbol_to_string,
+    is_vector, list_append, list_length, list_reverse, load_file, make_vector, max, min, modulo,
+    mult, new_list, new_string, new_vector, newline, not, num_to_string, or, pretty_print, print,
+    println, str_append, str_length, string_to_downcase, string_to_list, string_to_num,
+    string_to_symbol, string_to_upcase, sub, symbol_to_string, vector_len,
 };
 use crate::macros::{quote, set_car, set_cdr};
 use crate::types::Expr;
@@ -81,6 +81,10 @@ impl Env {
         data.insert("set-car!".to_string(), Expr::Procedure(set_car));
         data.insert("set-cdr!".to_string(), Expr::Procedure(set_cdr));
         data.insert("reverse".to_string(), Expr::Procedure(list_reverse));
+        // Vectors
+        data.insert("vector".to_string(), Expr::Procedure(new_vector));
+        data.insert("make-vector".to_string(), Expr::Procedure(make_vector));
+        data.insert("vector-length".to_string(), Expr::Procedure(vector_len));
         // Conversions
         data.insert("number->string".to_string(), Expr::Procedure(num_to_string));
         data.insert(
@@ -133,6 +137,7 @@ impl Env {
         data.insert("boolean?".to_string(), Expr::Procedure(is_boolean));
         data.insert("list?".to_string(), Expr::Procedure(is_list));
         data.insert("pair?".to_string(), Expr::Procedure(is_pair));
+        data.insert("vector?".to_string(), Expr::Procedure(is_vector));
         data.insert("procedure?".to_string(), Expr::Procedure(is_procedure));
         // Misc
         data.insert("exit".to_string(), Expr::Procedure(exit));

--- a/src/env/procedures.rs
+++ b/src/env/procedures.rs
@@ -599,6 +599,49 @@ pub fn list_to_vector(args: &[Expr], _: EnvRef) -> Result {
 /// Convert `Vector` to `Pair` list.
 pub fn vector_to_list(args: &[Expr], _: EnvRef) -> Result {
     match args {
+        [Expr::Vector(v), Expr::Number(start)] => {
+            if *start == Number::from_usize(v.len()) {
+                return Ok(Expr::Null);
+            }
+            let start = match start.to_usize() {
+                Some(s) => s,
+                None => {
+                    return Err(Error::Message(
+                        "invalid index, expected int or float".to_string(),
+                    ));
+                }
+            };
+            match v.sub_vector(start, v.len() - 1) {
+                Some(v) => Ok(Expr::Vector(v)),
+                None => Err(Error::Message("out of range".to_string())),
+            }
+        }
+        [Expr::Vector(v), Expr::Number(start), Expr::Number(end)] => {
+            let v_len = Number::from_usize(v.len());
+            if *start == v_len && *end == v_len {
+                return Ok(Expr::Null);
+            }
+            let start = match start.to_usize() {
+                Some(s) => s,
+                None => {
+                    return Err(Error::Message(
+                        "invalid index, expected int or float".to_string(),
+                    ));
+                }
+            };
+            let end = match end.to_usize() {
+                Some(s) => s,
+                None => {
+                    return Err(Error::Message(
+                        "invalid index, expected int or float".to_string(),
+                    ));
+                }
+            };
+            match v.sub_vector(start, end) {
+                Some(v) => Ok(Expr::Vector(v)),
+                None => Err(Error::Message("out of range".to_string())),
+            }
+        }
         [Expr::Vector(v)] => Ok(v.to_list()),
         _ => Err(Error::Message("expected vector".to_string())),
     }

--- a/src/env/procedures.rs
+++ b/src/env/procedures.rs
@@ -18,7 +18,7 @@ pub fn display(args: &[Expr], _: EnvRef) -> Result {
             print!("{}", arg);
             Ok(Expr::Void())
         }
-        _ => Err(Error::Message("expected 1 valid expression".to_string())),
+        _ => Err(Error::new("expected 1 valid expression")),
     }
 }
 
@@ -42,7 +42,7 @@ pub fn print(args: &[Expr], _: EnvRef) -> Result {
         return Ok(Expr::Void());
     }
 
-    Err(Error::Message("expected 1 valid expression".to_string()))
+    Err(Error::new("expected 1 valid expression"))
 }
 
 /// Print formatted value of expression in stdout with a newline.
@@ -59,14 +59,14 @@ pub fn println(args: &[Expr], _: EnvRef) -> Result {
         return Ok(Expr::Void());
     }
 
-    Err(Error::Message("expected 1 valid expression".to_string()))
+    Err(Error::new("expected 1 valid expression"))
 }
 
 /// Evaluate the contents of a file.
 pub fn load_file(args: &[Expr], env: EnvRef) -> Result {
     let file = match args.first() {
         Some(Expr::String(f)) => f,
-        _ => return Err(Error::Message("expected a string path".to_string())),
+        _ => return Err(Error::new("expected a string path")),
     };
 
     let expressions = io::file_input(file.to_owned());
@@ -92,7 +92,7 @@ pub fn pretty_print(args: &[Expr], _: EnvRef) -> Result {
             println!("{}", args[0]);
             return Ok(Expr::Void());
         }
-        None => return Err(Error::Message("expected ".to_string())),
+        None => return Err(Error::new("expected ")),
     }
 }
 
@@ -134,7 +134,7 @@ pub fn sub(args: &[Expr], _: EnvRef) -> Result {
 pub fn mult(args: &[Expr], _: EnvRef) -> Result {
     let numbers = parser::parse_number_list(args)?;
     if numbers.is_empty() {
-        return Err(Error::Message("expected at least one number".to_string()));
+        return Err(Error::new("expected at least one number"));
     }
     let initial_value: Number = Number::from_i64(1);
     let product = numbers
@@ -149,7 +149,7 @@ pub fn mult(args: &[Expr], _: EnvRef) -> Result {
 pub fn div(args: &[Expr], _: EnvRef) -> Result {
     let numbers = parser::parse_number_list(args)?;
     if numbers.is_empty() {
-        return Err(Error::Message("expected at least one number".to_string()));
+        return Err(Error::new("expected at least one number"));
     }
     let mut length_check_iter = numbers.clone().into_iter();
     length_check_iter.next();
@@ -172,7 +172,7 @@ pub fn div(args: &[Expr], _: EnvRef) -> Result {
 pub fn exponent(args: &[Expr], _: EnvRef) -> Result {
     match args {
         [Expr::Number(a), Expr::Number(b)] => Ok(Expr::Number(a.pow(b)?)),
-        _ => Err(Error::Message("expected 2 numbers".to_string())),
+        _ => Err(Error::new("expected 2 numbers")),
     }
 }
 
@@ -184,7 +184,7 @@ pub fn modulo(args: &[Expr], _: EnvRef) -> Result {
             let b = b.clone();
             Ok(Expr::Number((a % b)?))
         }
-        _ => Err(Error::Message("expected 2 numbers".to_string())),
+        _ => Err(Error::new("expected 2 numbers")),
     }
 }
 
@@ -205,7 +205,7 @@ pub fn abs(args: &[Expr], _: EnvRef) -> Result {
             }
             Ok(Expr::Number(n))
         }
-        _ => Err(Error::Message("expected 1 number".to_string())),
+        _ => Err(Error::new("expected 1 number")),
     }
 }
 
@@ -213,7 +213,7 @@ pub fn abs(args: &[Expr], _: EnvRef) -> Result {
 pub fn ceil(args: &[Expr], _: EnvRef) -> Result {
     match args {
         [Expr::Number(Number::Complex(_))] => {
-            Err(Error::Message("unable to round complex number".to_string()))
+            Err(Error::new("unable to round complex number"))
         }
         [Expr::Number(n)] => {
             if let Some(result) = n.to_f64() {
@@ -223,7 +223,7 @@ pub fn ceil(args: &[Expr], _: EnvRef) -> Result {
                 "unable to convert number to float".to_string(),
             ))
         }
-        _ => Err(Error::Message("expected real number".to_string())),
+        _ => Err(Error::new("expected real number")),
     }
 }
 
@@ -231,7 +231,7 @@ pub fn ceil(args: &[Expr], _: EnvRef) -> Result {
 pub fn floor(args: &[Expr], _: EnvRef) -> Result {
     match args {
         [Expr::Number(Number::Complex(_))] => {
-            Err(Error::Message("unable to round complex number".to_string()))
+            Err(Error::new("unable to round complex number"))
         }
         [Expr::Number(n)] => {
             if let Some(result) = n.to_f64() {
@@ -241,14 +241,14 @@ pub fn floor(args: &[Expr], _: EnvRef) -> Result {
                 "unable to convert number to float".to_string(),
             ))
         }
-        _ => Err(Error::Message("expected real number".to_string())),
+        _ => Err(Error::new("expected real number")),
     }
 }
 
 /// Return smallest real number from arguments.
 pub fn min(args: &[Expr], _: EnvRef) -> Result {
     if args.is_empty() {
-        return Err(Error::Message("expected real numbers".to_string()));
+        return Err(Error::new("expected real numbers"));
     }
 
     let mut min: Option<Number> = None;
@@ -257,7 +257,7 @@ pub fn min(args: &[Expr], _: EnvRef) -> Result {
         match arg {
             Expr::Number(current) => match current {
                 Number::Complex(_) => {
-                    return Err(Error::Message("expected real numbers".to_string()));
+                    return Err(Error::new("expected real numbers"));
                 }
                 _ => match min {
                     None => min = Some(current.clone()),
@@ -269,7 +269,7 @@ pub fn min(args: &[Expr], _: EnvRef) -> Result {
                 },
             },
             _ => {
-                return Err(Error::Message("expected real numbers".to_string()));
+                return Err(Error::new("expected real numbers"));
             }
         }
     }
@@ -280,7 +280,7 @@ pub fn min(args: &[Expr], _: EnvRef) -> Result {
 /// Return largest real number from arguments.
 pub fn max(args: &[Expr], _: EnvRef) -> Result {
     if args.is_empty() {
-        return Err(Error::Message("expected real numbers".to_string()));
+        return Err(Error::new("expected real numbers"));
     }
 
     let mut min: Option<Number> = None;
@@ -289,7 +289,7 @@ pub fn max(args: &[Expr], _: EnvRef) -> Result {
         match arg {
             Expr::Number(current) => match current {
                 Number::Complex(_) => {
-                    return Err(Error::Message("expected real numbers".to_string()));
+                    return Err(Error::new("expected real numbers"));
                 }
                 _ => match min {
                     None => min = Some(current.clone()),
@@ -301,7 +301,7 @@ pub fn max(args: &[Expr], _: EnvRef) -> Result {
                 },
             },
             _ => {
-                return Err(Error::Message("expected real numbers".to_string()));
+                return Err(Error::new("expected real numbers"));
             }
         }
     }
@@ -326,7 +326,7 @@ pub fn str_append(args: &[Expr], _: EnvRef) -> Result {
 pub fn str_length(args: &[Expr], _: EnvRef) -> Result {
     match args {
         [Expr::String(s)] => Ok(Expr::Number(Number::from_usize(s.len()))),
-        _ => Err(Error::Message("expected string".to_string())),
+        _ => Err(Error::new("expected string")),
     }
 }
 
@@ -335,7 +335,7 @@ pub fn new_string(args: &[Expr], _: EnvRef) -> Result {
     match args {
         [] => Ok(Expr::String(String::new())),
         [Expr::Char(c)] => Ok(Expr::String(String::from(*c))),
-        _ => Err(Error::Message("expected character".to_string())),
+        _ => Err(Error::new("expected character")),
     }
 }
 
@@ -349,7 +349,7 @@ pub fn string_to_upcase(args: &[Expr], _: EnvRef) -> Result {
                 .collect::<String>();
             return Ok(Expr::String(upcase));
         }
-        _ => Err(Error::Message("expected string".to_string())),
+        _ => Err(Error::new("expected string")),
     }
 }
 
@@ -363,7 +363,7 @@ pub fn string_to_downcase(args: &[Expr], _: EnvRef) -> Result {
                 .collect::<String>();
             return Ok(Expr::String(upcase));
         }
-        _ => Err(Error::Message("expected string".to_string())),
+        _ => Err(Error::new("expected string")),
     }
 }
 
@@ -396,7 +396,7 @@ pub fn cons_proc(args: &[Expr], _: EnvRef) -> Result {
     use crate::types::Pair;
     match args {
         [a, b] => Ok(Expr::Pair(Pair::cons((a.clone(), b.clone())))),
-        _ => Err(Error::Message("expected 2 arguments".to_string())),
+        _ => Err(Error::new("expected 2 arguments")),
     }
 }
 
@@ -412,7 +412,7 @@ pub fn list_append(args: &[Expr], _: EnvRef) -> Result {
             let result = list_a.clone().append(Expr::Pair(list_b.clone()))?;
             Ok(result)
         }
-        _ => Err(Error::Message("expected 2 lists".to_string())),
+        _ => Err(Error::new("expected 2 lists")),
     }
 }
 
@@ -420,7 +420,7 @@ pub fn list_append(args: &[Expr], _: EnvRef) -> Result {
 pub fn list_length(args: &[Expr], _: EnvRef) -> Result {
     match args {
         [Expr::Pair(p)] => Ok(Expr::Number(Number::from_usize(p.len()))),
-        _ => Err(Error::Message("expected list".to_string())),
+        _ => Err(Error::new("expected list")),
     }
 }
 
@@ -428,7 +428,7 @@ pub fn list_length(args: &[Expr], _: EnvRef) -> Result {
 pub fn car(args: &[Expr], _: EnvRef) -> Result {
     match args {
         [Expr::Pair(pair)] => Ok(pair.car()),
-        _ => Err(Error::Message("expected pair".to_string())),
+        _ => Err(Error::new("expected pair")),
     }
 }
 
@@ -436,7 +436,7 @@ pub fn car(args: &[Expr], _: EnvRef) -> Result {
 pub fn cdr(args: &[Expr], _: EnvRef) -> Result {
     match args {
         [Expr::Pair(pair)] => Ok(pair.cdr()),
-        _ => Err(Error::Message("expected pair".to_string())),
+        _ => Err(Error::new("expected pair")),
     }
 }
 
@@ -452,7 +452,7 @@ pub fn cadr(args: &[Expr], _: EnvRef) -> Result {
                 )),
             }
         }
-        _ => Err(Error::Message("expected list".to_string())),
+        _ => Err(Error::new("expected list")),
     }
 }
 
@@ -464,7 +464,7 @@ pub fn list_reverse(args: &[Expr], _: EnvRef) -> Result {
             let reversed: Vec<Expr> = items.into_iter().rev().collect::<Vec<_>>();
             Ok(Pair::list(&reversed))
         }
-        _ => Err(Error::Message("expected list".to_string())),
+        _ => Err(Error::new("expected list")),
     }
 }
 
@@ -498,7 +498,7 @@ pub fn vector_ref(args: &[Expr], _: EnvRef) -> Result {
         [Expr::Vector(v), Expr::Number(n)] => match n.to_usize() {
             Some(size) => match v.get(size) {
                 Some(e) => Ok(e.clone()),
-                _ => Err(Error::Message("invalid index".to_string())),
+                _ => Err(Error::new("invalid index")),
             },
             _ => Err(Error::Message(
                 "invalid length, expected int or float".to_string(),
@@ -516,7 +516,7 @@ pub fn vector_set(args: &[Expr], _: EnvRef) -> Result {
                 v.set(index, expr.clone())?;
                 Ok(Expr::Void())
             }
-            _ => Err(Error::Message("invalid index".to_string())),
+            _ => Err(Error::new("invalid index")),
         },
         _ => Err(Error::Message(
             "expected vector, index, and new value".to_string(),
@@ -528,7 +528,7 @@ pub fn vector_set(args: &[Expr], _: EnvRef) -> Result {
 pub fn vector_len(args: &[Expr], _: EnvRef) -> Result {
     match args {
         [Expr::Vector(v)] => Ok(Expr::Number(Number::from_usize(v.elements.borrow().len()))),
-        _ => Err(Error::Message("expected vector".to_string())),
+        _ => Err(Error::new("expected vector")),
     }
 }
 
@@ -538,7 +538,7 @@ pub fn vector_len(args: &[Expr], _: EnvRef) -> Result {
 pub fn num_to_string(args: &[Expr], _: EnvRef) -> Result {
     match args {
         [Expr::Number(num)] => Ok(Expr::String(String::from(num.to_string()))),
-        _ => Err(Error::Message("expected string".to_string())),
+        _ => Err(Error::new("expected string")),
     }
 }
 
@@ -549,7 +549,7 @@ pub fn string_to_num(args: &[Expr], _: EnvRef) -> Result {
             Ok(n) => Ok(Expr::Number(n)),
             Err(e) => Err(e),
         },
-        _ => Err(Error::Message("expected string".to_string())),
+        _ => Err(Error::new("expected string")),
     }
 }
 
@@ -557,7 +557,7 @@ pub fn string_to_num(args: &[Expr], _: EnvRef) -> Result {
 pub fn string_to_symbol(args: &[Expr], _: EnvRef) -> Result {
     match args {
         [Expr::String(s)] => Ok(Expr::Symbol(s.to_owned())),
-        _ => Err(Error::Message("expected string".to_string())),
+        _ => Err(Error::new("expected string")),
     }
 }
 
@@ -568,7 +568,7 @@ pub fn string_to_list(args: &[Expr], _: EnvRef) -> Result {
             let chars: Vec<Expr> = s.chars().map(|c| Expr::Char(c)).collect::<Vec<Expr>>();
             Ok(Pair::list(chars.as_slice()))
         }
-        _ => Err(Error::Message("expected string".to_string())),
+        _ => Err(Error::new("expected string")),
     }
 }
 
@@ -576,7 +576,7 @@ pub fn string_to_list(args: &[Expr], _: EnvRef) -> Result {
 pub fn string_to_vector(args: &[Expr], _: EnvRef) -> Result {
     match args {
         [Expr::String(s)] => Ok(Expr::Vector(Vector::from_string(s.clone()))),
-        _ => Err(Error::Message("expected string".to_string())),
+        _ => Err(Error::new("expected string")),
     }
 }
 
@@ -584,7 +584,7 @@ pub fn string_to_vector(args: &[Expr], _: EnvRef) -> Result {
 pub fn symbol_to_string(args: &[Expr], _: EnvRef) -> Result {
     match args {
         [Expr::Symbol(s)] => Ok(Expr::String(s.to_owned())),
-        _ => Err(Error::Message("expected string".to_string())),
+        _ => Err(Error::new("expected string")),
     }
 }
 
@@ -609,7 +609,7 @@ pub fn list_to_string(args: &[Expr], _: EnvRef) -> Result {
                     Expr::Pair(p) => p.to_expr_string(),
                     _ => unreachable!(),
                 },
-                None => Err(Error::Message("out of range".to_string())),
+                None => Err(Error::new("out of range")),
             }
         }
         [Expr::Pair(list), Expr::Number(n_start), Expr::Number(n_end)] if list.is_list() => {
@@ -637,10 +637,10 @@ pub fn list_to_string(args: &[Expr], _: EnvRef) -> Result {
                     Expr::Pair(p) => p.to_expr_string(),
                     _ => unreachable!(),
                 },
-                None => Err(Error::Message("out of range".to_string())),
+                None => Err(Error::new("out of range")),
             }
         }
-        _ => Err(Error::Message("expected proper list".to_string())),
+        _ => Err(Error::new("expected proper list")),
     }
 }
 
@@ -662,7 +662,7 @@ pub fn list_to_vector(args: &[Expr], _: EnvRef) -> Result {
             };
             match list.sub_list(start, list.len()) {
                 Some(list) => Ok(list),
-                None => Err(Error::Message("out of range".to_string())),
+                None => Err(Error::new("out of range")),
             }
         }
         [Expr::Pair(list), Expr::Number(n_start), Expr::Number(n_end)] if list.is_list() => {
@@ -692,10 +692,10 @@ pub fn list_to_vector(args: &[Expr], _: EnvRef) -> Result {
                         "unable to convert sub list to vector".to_string(),
                     )),
                 },
-                None => Err(Error::Message("out of range".to_string())),
+                None => Err(Error::new("out of range")),
             }
         }
-        _ => Err(Error::Message("expected proper list".to_string())),
+        _ => Err(Error::new("expected proper list")),
     }
 }
 
@@ -717,7 +717,7 @@ pub fn vector_to_list(args: &[Expr], _: EnvRef) -> Result {
             };
             match vec.sub_vector(start, vec.len()) {
                 Some(v) => Ok(v.to_expr_list()),
-                None => Err(Error::Message("out of range".to_string())),
+                None => Err(Error::new("out of range")),
             }
         }
         [Expr::Vector(vec), Expr::Number(start), Expr::Number(end)] => {
@@ -743,10 +743,10 @@ pub fn vector_to_list(args: &[Expr], _: EnvRef) -> Result {
             };
             match vec.sub_vector(start, end) {
                 Some(v) => Ok(v.to_expr_list()),
-                None => Err(Error::Message("out of range".to_string())),
+                None => Err(Error::new("out of range")),
             }
         }
-        _ => Err(Error::Message("expected vector".to_string())),
+        _ => Err(Error::new("expected vector")),
     }
 }
 
@@ -768,7 +768,7 @@ pub fn vector_to_string(args: &[Expr], _: EnvRef) -> Result {
             };
             match vec.sub_vector(start, vec.len()) {
                 Some(v) => Ok(v.to_expr_string()?),
-                None => Err(Error::Message("out of range".to_string())),
+                None => Err(Error::new("out of range")),
             }
         }
         [Expr::Vector(vec), Expr::Number(start), Expr::Number(end)] => {
@@ -794,10 +794,10 @@ pub fn vector_to_string(args: &[Expr], _: EnvRef) -> Result {
             };
             match vec.sub_vector(start, end) {
                 Some(v) => Ok(v.to_expr_string()?),
-                None => Err(Error::Message("out of range".to_string())),
+                None => Err(Error::new("out of range")),
             }
         }
-        _ => Err(Error::Message("expected vector".to_string())),
+        _ => Err(Error::new("expected vector")),
     }
 }
 
@@ -870,7 +870,7 @@ pub fn is_even(args: &[Expr], _: EnvRef) -> Result {
             let remainder = (n.clone() % Number::Int(Small(2)))?;
             Ok(Expr::Boolean(remainder == Number::Int(Small(0))))
         }
-        _ => Err(Error::Message("expected one argument".to_string())),
+        _ => Err(Error::new("expected one argument")),
     }
 }
 
@@ -881,7 +881,7 @@ pub fn is_odd(args: &[Expr], _: EnvRef) -> Result {
             let remainder = (n.clone() % Number::Int(Small(2)))?;
             Ok(Expr::Boolean(remainder == Number::Int(Small(1))))
         }
-        _ => Err(Error::Message("expected a number".to_string())),
+        _ => Err(Error::new("expected a number")),
     }
 }
 
@@ -894,7 +894,7 @@ pub fn is_exact(args: &[Expr], _: EnvRef) -> Result {
         [Expr::Number(Number::Float(_))] | [Expr::Number(Number::Complex(_))] => {
             Ok(Expr::Boolean(false))
         }
-        _ => Err(Error::Message("expected a number".to_string())),
+        _ => Err(Error::new("expected a number")),
     }
 }
 
@@ -907,7 +907,7 @@ pub fn is_inexact(args: &[Expr], _: EnvRef) -> Result {
         [Expr::Number(Number::Int(_))] | [Expr::Number(Number::Rational(_))] => {
             Ok(Expr::Boolean(false))
         }
-        _ => Err(Error::Message("expected a number".to_string())),
+        _ => Err(Error::new("expected a number")),
     }
 }
 
@@ -916,7 +916,7 @@ pub fn is_exact_integer(args: &[Expr], _: EnvRef) -> Result {
     match args {
         [Expr::Number(Number::Int(_))] => Ok(Expr::Boolean(true)),
         [Expr::Number(_)] => Ok(Expr::Boolean(false)),
-        _ => Err(Error::Message("expected a number".to_string())),
+        _ => Err(Error::new("expected a number")),
     }
 }
 

--- a/src/env/procedures.rs
+++ b/src/env/procedures.rs
@@ -591,10 +591,7 @@ pub fn symbol_to_string(args: &[Expr], _: EnvRef) -> Result {
 /// WIP! Convert `Pair` list to `String`.
 pub fn list_to_string(args: &[Expr], _: EnvRef) -> Result {
     match args {
-        [Expr::Pair(p)] if p.is_list() => {
-            let pair = Expr::Pair(p.clone());
-            Ok(Expr::String(pair.to_string()))
-        }
+        [Expr::Pair(p)] if p.is_list() => p.to_string(),
         [Expr::Pair(list), Expr::Number(n_start)] if list.is_list() => {
             if *n_start == Number::from_usize(list.len()) {
                 return Ok(Expr::Null);
@@ -608,7 +605,10 @@ pub fn list_to_string(args: &[Expr], _: EnvRef) -> Result {
                 }
             };
             match list.sub_list(start, list.len()) {
-                Some(list) => Ok(Expr::String(list.to_string())),
+                Some(list) => match list {
+                    Expr::Pair(p) => p.to_string(),
+                    _ => unreachable!(),
+                },
                 None => Err(Error::Message("out of range".to_string())),
             }
         }
@@ -633,7 +633,10 @@ pub fn list_to_string(args: &[Expr], _: EnvRef) -> Result {
                 }
             };
             match list.sub_list(start, end) {
-                Some(list) => Ok(Expr::String(list.to_string())),
+                Some(list) => match list {
+                    Expr::Pair(p) => p.to_string(),
+                    _ => unreachable!(),
+                },
                 None => Err(Error::Message("out of range".to_string())),
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,3 +18,9 @@ impl fmt::Display for Error {
         }
     }
 }
+
+impl Error {
+    pub fn new(message: &str) -> Error {
+        Error::Message(String::from(message))
+    }
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -5,7 +5,7 @@
 //! Functions for REPL IO.
 
 use std::fs::File;
-use std::io::{self, stdout, BufRead, Write};
+use std::io::{self, BufRead, Write, stdout};
 use std::process;
 
 use colored::{self, Colorize};
@@ -15,7 +15,7 @@ use crate::error::Error;
 use crate::parser;
 use crate::types::Expr;
 
-pub const COPPER_VERSION: &str = "0.2.3";
+pub const COPPER_VERSION: &str = "0.3.0";
 
 /// Get expression from stdin.
 pub fn stdin_input() -> String {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -19,7 +19,7 @@ pub fn define(args: &[Expr], env: EnvRef) -> Result<Expr, Error> {
             let name = match pair.get(0) {
                 Some(Expr::Symbol(s)) => s,
                 _ => {
-                    return Err(Error::Message("ill-formed special form name".to_string()));
+                    return Err(Error::new("ill-formed special form name"));
                 }
             };
 
@@ -28,7 +28,7 @@ pub fn define(args: &[Expr], env: EnvRef) -> Result<Expr, Error> {
             env.borrow_mut().data.insert(name.to_owned(), value);
         }
         _ => {
-            return Err(Error::Message("ill-formed special form".to_string()));
+            return Err(Error::new("ill-formed special form"));
         }
     }
     Ok(Expr::Void())
@@ -45,7 +45,7 @@ pub fn set_car(args: &[Expr], env_ref: EnvRef) -> Result<Expr, Error> {
                         let new_value = eval(&expr, env_ref.clone())?;
                         pair.set_car(new_value.clone());
                     }
-                    _ => return Err(Error::Message("pair expected".to_string())),
+                    _ => return Err(Error::new("pair expected")),
                 }
             }
         }
@@ -53,7 +53,7 @@ pub fn set_car(args: &[Expr], env_ref: EnvRef) -> Result<Expr, Error> {
             let new_value = eval(&expr, env_ref.clone())?;
             pair.set_car(new_value.clone());
         }
-        [] => return Err(Error::Message("expected 2 arguments".to_string())),
+        [] => return Err(Error::new("expected 2 arguments")),
         _ => {}
     }
 
@@ -71,7 +71,7 @@ pub fn set_cdr(args: &[Expr], env_ref: EnvRef) -> Result<Expr, Error> {
                         let new_value = eval(&expr, env_ref.clone())?;
                         pair.set_cdr(new_value.clone());
                     }
-                    _ => return Err(Error::Message("expected pair".to_string())),
+                    _ => return Err(Error::new("expected pair")),
                 }
             }
         }
@@ -79,7 +79,7 @@ pub fn set_cdr(args: &[Expr], env_ref: EnvRef) -> Result<Expr, Error> {
             let new_value = eval(&expr, env_ref.clone())?;
             pair.set_cdr(new_value.clone());
         }
-        [] => return Err(Error::Message("expected 2 arguments".to_string())),
+        [] => return Err(Error::new("expected 2 arguments")),
         _ => {}
     }
 
@@ -118,7 +118,7 @@ pub fn lambda(args: &[Expr], env: EnvRef) -> Result<Expr, Error> {
     // Get function.
     let body = match iter.next() {
         Some(e) => e,
-        _ => return Err(Error::Message("expected lambda body".to_string())),
+        _ => return Err(Error::new("expected lambda body")),
     };
 
     let closure = Box::new(Closure::init(env.clone(), params, body.clone()));
@@ -150,7 +150,7 @@ pub fn apply_lambda(closure: &Closure, args: Vec<Expr>) -> Result<Expr, Error> {
 pub fn quote(args: &[Expr], _: EnvRef) -> Result<Expr, Error> {
     match args {
         [expr] => Ok(expr.clone()),
-        _ => Err(Error::Message("quote expects 1 argument".to_string())),
+        _ => Err(Error::new("quote expects 1 argument")),
     }
 }
 
@@ -164,7 +164,7 @@ pub fn if_statement(args: &[Expr], env: EnvRef) -> Result<Expr, Error> {
                 _ => eval(first_branch, env),
             }
         }
-        _ => Err(Error::Message("ill-formed special form".to_string())),
+        _ => Err(Error::new("ill-formed special form")),
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -69,7 +69,7 @@ pub fn eval(expr: &Expr, env: EnvRef) -> Result<Expr, Error> {
         }
         Expr::Void() => Ok(Expr::Void()),
         Expr::Null => Ok(Expr::Null),
-        _ => Err(Error::Message("unexpected form".to_string())),
+        _ => Err(Error::new("unexpected form")),
     }
 }
 
@@ -81,11 +81,11 @@ pub fn parse(tokens: &[String]) -> Result<(Expr, &[String]), Error> {
 
     let (token, right_expr) = tokens
         .split_first()
-        .ok_or(Error::Message("could not parse first token".to_string()))?;
+        .ok_or(Error::new("could not parse first token"))?;
 
     match &token[..] {
         "(" => parse_right_expr(right_expr),
-        ")" => Err(Error::Message("invalid ')'".to_string())),
+        ")" => Err(Error::new("invalid ')'")),
         "'" => {
             let (quoted_expr, remaining) = parse(right_expr)?;
             let slice = vec![Expr::Symbol("quote".to_string()), quoted_expr];
@@ -107,8 +107,8 @@ pub fn parse_right_expr(tokens: &[String]) -> Result<(Expr, &[String]), Error> {
     let mut expressions: Vec<Expr> = vec![];
     let mut tokens_copy = tokens;
     loop {
-        let (car, cdr) = tokens_copy.split_first().ok_or(Error::Message(
-            "unable to parse rest of expression".to_string(),
+        let (car, cdr) = tokens_copy.split_first().ok_or(Error::new(
+            "unable to parse rest of expression",
         ))?;
         if car == ")" {
             return Ok((Pair::list(expressions.as_slice()), cdr));
@@ -126,7 +126,7 @@ pub fn parse_vector_literal(tokens: &[String]) -> Result<(Expr, &[String]), Erro
     loop {
         let (car, cdr) = tokens_copy
             .split_first()
-            .ok_or(Error::Message("unable to parse vector literal".to_string()))?;
+            .ok_or(Error::new("unable to parse vector literal"))?;
         if car == ")" {
             let mut vector_form = vec![Expr::Symbol("vector".to_string())];
             vector_form.extend(expressions);
@@ -208,7 +208,7 @@ pub fn parse_number_list(expressions: &[Expr]) -> Result<Vec<Number>, Error> {
 pub fn parse_number(expr: &Expr) -> Result<Number, Error> {
     match expr {
         Expr::Number(num) => Ok(num.clone()),
-        _ => Err(Error::Message("expected a number".to_string())),
+        _ => Err(Error::new("expected a number")),
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -728,6 +728,156 @@ fn test_symbol_to_string() {
     assert!(matches!(result, _expected));
 }
 
+#[test]
+fn test_string_to_list() {
+    use crate::{env::Env, parser::parse_and_eval, types::Expr, types::Pair};
+    let env = Env::standard_env();
+    let input = "(string->list \"hello\")".to_string();
+    let result = parse_and_eval(input, env);
+    let expected_values = vec![
+        Expr::Char('h'),
+        Expr::Char('e'),
+        Expr::Char('l'),
+        Expr::Char('l'),
+        Expr::Char('o'),
+    ];
+    let _expected = Pair::list(expected_values.as_slice());
+    assert!(matches!(result, Ok(_expected)));
+}
+
+#[test]
+fn test_string_to_list_empty() {
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    let env = Env::standard_env();
+    let input = "(string->list \"\")".to_string();
+    let result = parse_and_eval(input, env);
+    assert!(matches!(result, Ok(Expr::Null)));
+}
+
+#[test]
+fn test_string_to_vector() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let input = "(string->vector \"abc\")".to_string();
+    let result = parse_and_eval(input, env);
+    assert!(result.is_ok());
+    if let Ok(expr) = result {
+        assert!(matches!(expr, crate::types::Expr::Vector(_)));
+    }
+}
+
+#[test]
+fn test_list_to_string() {
+    use crate::{env::Env, error::Error, parser::parse_and_eval, types::Expr};
+    let env = Env::standard_env();
+    let input = "(list->string (list #\\h #\\i))".to_string();
+    let result = parse_and_eval(input, env);
+    let _expected: Result<Expr, Error> = Ok(Expr::String("hi".to_string()));
+    assert!(matches!(result, _expected));
+}
+
+#[test]
+fn test_list_to_string_with_start() {
+    use crate::{env::Env, error::Error, parser::parse_and_eval, types::Expr};
+    let env = Env::standard_env();
+    let input = "(list->string (list #\\h #\\e #\\l #\\l #\\o) 1)".to_string();
+    let result = parse_and_eval(input, env);
+    let _expected: Result<Expr, Error> = Ok(Expr::String("ello".to_string()));
+    assert!(matches!(result, _expected));
+}
+
+#[test]
+fn test_list_to_string_with_start_and_end() {
+    use crate::{env::Env, error::Error, parser::parse_and_eval, types::Expr};
+    let env = Env::standard_env();
+    let input = "(list->string (list #\\h #\\e #\\l #\\l #\\o) 1 4)".to_string();
+    let result = parse_and_eval(input, env);
+    let _expected: Result<Expr, Error> = Ok(Expr::String("ell".to_string()));
+    assert!(matches!(result, _expected));
+}
+
+#[test]
+fn test_list_to_vector() {
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    let env = Env::standard_env();
+    let input = "(list->vector (list 1 2 3))".to_string();
+    let result = parse_and_eval(input, env);
+    assert!(result.is_ok());
+    if let Ok(expr) = result {
+        assert!(matches!(expr, Expr::Vector(_)));
+    }
+}
+
+#[test]
+fn test_list_to_vector_with_start() {
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    let env = Env::standard_env();
+    let input = "(list->vector (list 1 2 3 4) 1)".to_string();
+    let result = parse_and_eval(input, env);
+    assert!(result.is_ok());
+    if let Ok(expr) = result {
+        assert!(matches!(expr, Expr::Pair(_)));
+    }
+}
+
+#[test]
+fn test_list_to_vector_with_start_and_end() {
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    let env = Env::standard_env();
+    let input = "(list->vector (list 1 2 3 4 5) 1 4)".to_string();
+    let result = parse_and_eval(input, env);
+    assert!(result.is_ok());
+    if let Ok(expr) = result {
+        assert!(matches!(expr, Expr::Vector(_)));
+    }
+}
+
+#[test]
+fn test_vector_to_list() {
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    let env = Env::standard_env();
+    let input = "(vector->list (vector 1 2 3))".to_string();
+    let result = parse_and_eval(input, env);
+    assert!(result.is_ok());
+    if let Ok(expr) = result {
+        assert!(matches!(expr, Expr::Pair(_)));
+    }
+}
+
+#[test]
+fn test_vector_to_list_with_start() {
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    let env = Env::standard_env();
+    let input = "(vector->list (vector 1 2 3 4) 2)".to_string();
+    let result = parse_and_eval(input, env);
+    assert!(result.is_ok());
+    if let Ok(expr) = result {
+        assert!(matches!(expr, Expr::Vector(_)));
+    }
+}
+
+#[test]
+fn test_vector_to_list_with_start_and_end() {
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    let env = Env::standard_env();
+    let input = "(vector->list (vector 1 2 3 4 5) 1 3)".to_string();
+    let result = parse_and_eval(input, env);
+    assert!(result.is_ok());
+    if let Ok(expr) = result {
+        assert!(matches!(expr, Expr::Vector(_)));
+    }
+}
+
+#[test]
+fn test_vector_to_string() {
+    use crate::{env::Env, error::Error, parser::parse_and_eval, types::Expr};
+    let env = Env::standard_env();
+    let input = "(vector->string (vector #\\a #\\b #\\c))".to_string();
+    let result = parse_and_eval(input, env);
+    let _expected: Result<Expr, Error> = Ok(Expr::String("abc".to_string()));
+    assert!(matches!(result, _expected));
+}
+
 // Predicate Functions
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -815,8 +815,8 @@ fn test_list_to_vector_with_start() {
     let input = "(list->vector (list 1 2 3 4) 1)".to_string();
     let result = parse_and_eval(input, env);
     assert!(result.is_ok());
-    if let Ok(expr) = result {
-        assert!(matches!(expr, Expr::Pair(_)));
+    if let Ok(Expr::Pair(p)) = result {
+        assert!(p.is_list());
     }
 }
 
@@ -839,8 +839,8 @@ fn test_vector_to_list() {
     let input = "(vector->list (vector 1 2 3))".to_string();
     let result = parse_and_eval(input, env);
     assert!(result.is_ok());
-    if let Ok(expr) = result {
-        assert!(matches!(expr, Expr::Pair(_)));
+    if let Ok(Expr::Pair(p)) = result {
+        assert!(p.is_list());
     }
 }
 
@@ -851,8 +851,8 @@ fn test_vector_to_list_with_start() {
     let input = "(vector->list (vector 1 2 3 4) 2)".to_string();
     let result = parse_and_eval(input, env);
     assert!(result.is_ok());
-    if let Ok(expr) = result {
-        assert!(matches!(expr, Expr::Vector(_)));
+    if let Ok(Expr::Pair(p)) = result {
+        assert!(p.is_list());
     }
 }
 
@@ -863,8 +863,8 @@ fn test_vector_to_list_with_start_and_end() {
     let input = "(vector->list (vector 1 2 3 4 5) 1 3)".to_string();
     let result = parse_and_eval(input, env);
     assert!(result.is_ok());
-    if let Ok(expr) = result {
-        assert!(matches!(expr, Expr::Vector(_)));
+    if let Ok(Expr::Pair(p)) = result {
+        assert!(p.is_list());
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -961,7 +961,7 @@ fn test_list_get_invalid_element() {
         Expr::Pair(Pair::cons((Expr::Number(Number::from_i64(1)), Expr::Null))),
     ));
     let result = pair.get(2);
-    assert!(matches!(result, None));
+    assert!(matches!(result, Some(Expr::Null)));
 }
 
 #[test]
@@ -975,8 +975,7 @@ fn test_list_get_last_element() {
         ))),
     ));
     let result = pair.get(4);
-    println!("result: {:?}", result);
-    assert!(matches!(result, None));
+    assert!(matches!(result, Some(Expr::Null)));
 }
 
 #[test]
@@ -988,7 +987,7 @@ fn test_create_list() {
         Expr::Number(Number::from_i64(2)),
     ];
     let list = Pair::list(&expr);
-    println!("list: {:?}", list);
+    assert!(matches!(list, Expr::Pair(_)));
 }
 
 #[test]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -479,4 +479,21 @@ impl Vector {
         let chars = s.chars().map(|c| Expr::Char(c)).collect::<Vec<Expr>>();
         Vector::from(chars.as_slice())
     }
+
+    /// Return a new sub `Vector` with the given indices.
+    pub fn sub_vector(&self, start: usize, end: usize) -> Option<Vector> {
+        let vec_ref = self.elements.borrow();
+        match (vec_ref.get(start), vec_ref.get(end - 1)) {
+            (Some(_), Some(_)) => {
+                let sub_slice = &vec_ref[start..end];
+                Some(Vector::from(sub_slice))
+            }
+            _ => None,
+        }
+    }
+
+    /// Return length of `Vector`.
+    pub fn len(&self) -> usize {
+        self.elements.borrow().len()
+    }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -18,6 +18,7 @@ pub const BOOLEAN_TRUE_STR: &str = "#t";
 pub const BOOLEAN_FALSE_STR: &str = "#f";
 
 pub type Result = std::result::Result<Expr, Error>;
+pub type Vector = Vec<Expr>;
 pub type Procedure = fn(&[Expr], EnvRef) -> Result;
 
 #[derive(Debug, Clone)]
@@ -29,9 +30,10 @@ pub enum Expr {
     Symbol(String),
     Pair(Pair),
     Null,
-    Void(),
+    Vector(Vec<Expr>),
     Procedure(Procedure),
     Closure(Box<Closure>),
+    Void(),
 }
 
 impl fmt::Display for Expr {
@@ -42,11 +44,12 @@ impl fmt::Display for Expr {
             Expr::Char(c) => format_char(c),
             Expr::Boolean(b) => format_boolean(b),
             Expr::Symbol(s) => s.clone(),
-            Expr::Pair(pair) => format_pair(pair),
+            Expr::Pair(p) => format_pair(p),
             Expr::Null => format_null(),
-            Expr::Void() => return Ok(()),
+            Expr::Vector(v) => format_vector(v, true),
             Expr::Procedure(_) => "#<function {}".to_string(),
             Expr::Closure(_) => "#<procedure {}>".to_string(),
+            Expr::Void() => return Ok(()),
         };
         write!(f, "{}", s)
     }
@@ -72,11 +75,30 @@ fn format_boolean(b: &bool) -> String {
 
 /// Format pair into literal representation.
 pub fn format_pair(pair: &Pair) -> String {
-    format!(
-        "({} . {})",
-        pair.elements.borrow().0,
-        pair.elements.borrow().1
-    )
+    // TODO: format real lists
+    match pair.is_list() {
+        true => format!(
+            "({} . {})",
+            pair.elements.borrow().0,
+            pair.elements.borrow().1
+        ),
+        false => format!(""),
+    }
+}
+
+/// Format vector into literal representation.
+fn format_vector(vector: &Vector, literal: bool) -> String {
+    let items = vector
+        .iter()
+        .map(|e| e.to_string())
+        .collect::<Vec<String>>()
+        .join(" ");
+
+    if literal {
+        return format!("#({})", items);
+    }
+
+    items
 }
 
 /// Return literal representation of a null list.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -203,7 +203,7 @@ impl Pair {
                 let borrowed = curr_pair.elements.borrow();
                 match &borrowed.1 {
                     Expr::Pair(p) => match p.elements.borrow().1 {
-                        Expr::Null => return None,
+                        Expr::Null => return Some(Expr::Null),
                         _ => p.clone(),
                     },
                     _ => return None,
@@ -213,10 +213,10 @@ impl Pair {
         }
 
         let curr_element = curr_pair.elements.borrow();
-        if even == 0 {
-            return Some(curr_element.1.clone());
+        return if even == 0 {
+            Some(curr_element.1.clone())
         } else {
-            return Some(curr_element.0.clone());
+            Some(curr_element.0.clone())
         }
     }
 
@@ -287,7 +287,7 @@ impl Pair {
 
     /// Return the number of elements in the `Pair` or list.
     pub fn len(&self) -> usize {
-        let mut len: usize = 0;
+        let mut len: usize = 1;
         let mut current = self.clone();
 
         loop {
@@ -326,6 +326,18 @@ impl Pair {
     pub fn to_vector(&self) -> Expr {
         let pair_elements: Vec<Expr> = self.iter().collect();
         Expr::Vector(Vector::from(pair_elements.as_slice()))
+    }
+
+    /// Return a new sub `Vector` with the given indices. `start` is inclusive and `end` is exclusive. Return `None` if `&self` is not a list.
+    pub fn sub_list(&self, start: usize, end: usize) -> Option<Expr> {
+        let len = self.len();
+        if start < len && end <= len {
+            let vector = self.iter().collect::<Vec<Expr>>();
+            let sub_list = &vector.as_slice()[start..end];
+            return Some(Pair::list(sub_list))
+        }
+
+        None
     }
 }
 
@@ -480,7 +492,7 @@ impl Vector {
         Vector::from(chars.as_slice())
     }
 
-    /// Return a new sub `Vector` with the given indices.
+    /// Return a new sub `Vector` with the given indices. `start` is inclusive and `end` is exclusive.
     pub fn sub_vector(&self, start: usize, end: usize) -> Option<Vector> {
         let vec_ref = self.elements.borrow();
         match (vec_ref.get(start), vec_ref.get(end - 1)) {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -323,13 +323,13 @@ impl Pair {
     }
 
     /// Return `Vector` created from `&self` elements.
-    pub fn to_vector(&self) -> Expr {
+    pub fn to_expr_vector(&self) -> Expr {
         let pair_elements: Vec<Expr> = self.iter().collect();
         Expr::Vector(Vector::from(pair_elements.as_slice()))
     }
 
     /// Return `String` created from `&self` elements.
-    pub fn to_string(&self) -> Result {
+    pub fn to_expr_string(&self) -> Result {
         let pair_elements = self
             .iter()
             .map(|e| match e {
@@ -478,14 +478,14 @@ impl Vector {
         }
     }
 
-    /// Return new `Pair` list created from `&self`.
-    pub fn to_list(&self) -> Expr {
+    /// Return new `Expr::Pair` list created from `&self`.
+    pub fn to_expr_list(&self) -> Expr {
         let vec_ref = self.elements.borrow();
         Pair::list(vec_ref.as_slice())
     }
 
-    /// Return new `String` created from `&self`.
-    pub fn to_string(&self) -> Result {
+    /// Return new `Expr::String` created from `&self`.
+    pub fn to_expr_string(&self) -> Result {
         let str_elements = self
             .elements
             .borrow()

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -507,17 +507,54 @@ impl Vector {
     /// Return a new sub `Vector` with the given indices. `start` is inclusive and `end` is exclusive.
     pub fn sub_vector(&self, start: usize, end: usize) -> Option<Vector> {
         let vec_ref = self.elements.borrow();
-        match (vec_ref.get(start), vec_ref.get(end - 1)) {
-            (Some(_), Some(_)) => {
-                let sub_slice = &vec_ref[start..end];
-                Some(Vector::from(sub_slice))
-            }
-            _ => None,
+        let len = self.len();
+        if start < len && end <= len {
+            let sub_slice = &vec_ref[start..end];
+            return Some(Vector::from(sub_slice));
         }
+
+        None
     }
 
     /// Return length of `Vector`.
     pub fn len(&self) -> usize {
         self.elements.borrow().len()
+    }
+
+    /// Set each element from `start` to `end` as `new_value`.
+    pub fn fill(
+        &self,
+        new_value: &Expr,
+        start: usize,
+        end: usize,
+    ) -> std::result::Result<(), Error> {
+        let len = self.len();
+        if start < len && end <= len {
+            self.elements
+                .borrow_mut()
+                .iter_mut()
+                .enumerate()
+                .skip(start)
+                .take(end - start)
+                .for_each(|(_, e)| {
+                    *e = new_value.clone();
+                });
+
+            return Ok(());
+        }
+
+        Err(Error::new("out of range"))
+    }
+
+    /// Append elements from `other` into `&self`, leaving `other` empty.
+    pub fn append(&self, other: Vector) {
+        let mut other_elements = other.elements.borrow_mut();
+        self.elements.borrow_mut().append(&mut other_elements)
+    }
+
+    /// Return a deep copy of `&self.elements`.
+    pub fn deep_copy(&self) -> Vector {
+        let copied_elements: Vec<Expr> = self.elements.borrow().iter().map(|e| e.clone()).collect();
+        Vector::from(copied_elements.as_slice())
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -217,7 +217,7 @@ impl Pair {
             Some(curr_element.1.clone())
         } else {
             Some(curr_element.0.clone())
-        }
+        };
     }
 
     /// Set element from list.
@@ -328,13 +328,25 @@ impl Pair {
         Expr::Vector(Vector::from(pair_elements.as_slice()))
     }
 
+    /// Return `String` created from `&self` elements.
+    pub fn to_string(&self) -> Result {
+        let pair_elements = self
+            .iter()
+            .map(|e| match e {
+                Expr::Char(c) => Ok(c),
+                _ => return Err(Error::Message("expected char".to_string())),
+            })
+            .collect::<std::result::Result<String, Error>>()?;
+        Ok(Expr::String(pair_elements))
+    }
+
     /// Return a new sub `Vector` with the given indices. `start` is inclusive and `end` is exclusive. Return `None` if `&self` is not a list.
     pub fn sub_list(&self, start: usize, end: usize) -> Option<Expr> {
         let len = self.len();
         if start < len && end <= len {
             let vector = self.iter().collect::<Vec<Expr>>();
             let sub_list = &vector.as_slice()[start..end];
-            return Some(Pair::list(sub_list))
+            return Some(Pair::list(sub_list));
         }
 
         None

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -334,7 +334,7 @@ impl Pair {
             .iter()
             .map(|e| match e {
                 Expr::Char(c) => Ok(c),
-                _ => return Err(Error::Message("expected char".to_string())),
+                _ => return Err(Error::new("expected char")),
             })
             .collect::<std::result::Result<String, Error>>()?;
         Ok(Expr::String(pair_elements))
@@ -465,7 +465,7 @@ impl Vector {
                 vec_ref[index] = new_value;
                 Ok(())
             }
-            None => Err(Error::Message("".to_string())),
+            None => Err(Error::new("")),
         }
     }
 
@@ -492,7 +492,7 @@ impl Vector {
             .iter()
             .map(|e| match e {
                 Expr::Char(c) => Ok(*c),
-                _ => return Err(Error::Message("expected char".to_string())),
+                _ => return Err(Error::new("expected char")),
             })
             .collect::<std::result::Result<String, Error>>()?;
         Ok(Expr::String(str_elements))

--- a/src/types/number.rs
+++ b/src/types/number.rs
@@ -68,7 +68,7 @@ impl Number {
                         let im = im_part_str.parse::<f64>().map_err(ParseFloatError::from);
                         return match (re, im) {
                             (Ok(re), Ok(im)) => Ok(Complex(Complex64::new(re, im))),
-                            _ => Err(Error::Message("unable to parse complex number".to_string())),
+                            _ => Err(Error::new("unable to parse complex number")),
                         };
                     }
                 } else if parts.len() == 1
@@ -243,10 +243,10 @@ impl Number {
                     IntVariant::Small(i) => *i as f64,
                     IntVariant::Big(b) => b
                         .to_f64()
-                        .ok_or(Error::Message("unable to convert base to f64".to_string()))?,
+                        .ok_or(Error::new("unable to convert base to f64"))?,
                 };
-                let exp_float = exponent.to_f64().ok_or(Error::Message(
-                    "unable to convert exponent to f64".to_string(),
+                let exp_float = exponent.to_f64().ok_or(Error::new(
+                    "unable to convert exponent to f64",
                 ))?;
                 let result = base_float.powf(exp_float);
 
@@ -257,7 +257,7 @@ impl Number {
                     IntVariant::Small(i) => *i as f64,
                     IntVariant::Big(b) => b
                         .to_f64()
-                        .ok_or(Error::Message("unable to convert base to f64".to_string()))?,
+                        .ok_or(Error::new("unable to convert base to f64"))?,
                 };
                 let result = base_float.powf(*exponent);
                 Ok(Number::rationalize_float(result))
@@ -291,9 +291,9 @@ impl Number {
             (Rational(base), Rational(exponent)) => {
                 let base_float = base
                     .to_f64()
-                    .ok_or(Error::Message("unable to convert base to f64".to_string()))?;
-                let exp_float = exponent.to_f64().ok_or(Error::Message(
-                    "unable to convert exponent to f64".to_string(),
+                    .ok_or(Error::new("unable to convert base to f64"))?;
+                let exp_float = exponent.to_f64().ok_or(Error::new(
+                    "unable to convert exponent to f64",
                 ))?;
                 let result = base_float.powf(exp_float);
                 Ok(Number::rationalize_float(result))
@@ -301,7 +301,7 @@ impl Number {
             (Rational(base), Float(exponent)) => {
                 let base_float = base
                     .to_f64()
-                    .ok_or(Error::Message("unable to convert base to f64".to_string()))?;
+                    .ok_or(Error::new("unable to convert base to f64"))?;
                 let result = base_float.powf(*exponent);
                 Ok(Number::rationalize_float(result))
             }
@@ -317,8 +317,8 @@ impl Number {
                 Ok(Number::rationalize_float(result))
             }
             (Float(base), Rational(exponent)) => {
-                let exp_float = exponent.to_f64().ok_or(Error::Message(
-                    "unable to convert exponent to f64".to_string(),
+                let exp_float = exponent.to_f64().ok_or(Error::new(
+                    "unable to convert exponent to f64",
                 ))?;
                 let result = base.powf(exp_float);
                 Ok(Number::rationalize_float(result))
@@ -336,9 +336,9 @@ impl Number {
     fn pow_via_float(&self, exponent: &Number) -> Result<Number, Error> {
         let base_float = self
             .to_f64()
-            .ok_or(Error::Message("unable to convert base to f64".to_string()))?;
-        let exp_float = exponent.to_f64().ok_or(Error::Message(
-            "unable to convert exponent to f64".to_string(),
+            .ok_or(Error::new("unable to convert base to f64"))?;
+        let exp_float = exponent.to_f64().ok_or(Error::new(
+            "unable to convert exponent to f64",
         ))?;
         let result = base_float.powf(exp_float);
         Ok(Number::rationalize_float(result))
@@ -588,13 +588,13 @@ impl Div for Number {
         // Pre-check for division by exact zero
         match &other {
             Int(IntVariant::Small(0)) => {
-                return Err(Error::Message("unable to divide by 0".to_string()));
+                return Err(Error::new("unable to divide by 0"));
             }
             Int(IntVariant::Big(b)) if b == &BigInt::from(0) => {
-                return Err(Error::Message("unable to divide by 0".to_string()));
+                return Err(Error::new("unable to divide by 0"));
             }
             Rational(r) if r.is_zero() => {
-                return Err(Error::Message("unable to divide by 0".to_string()));
+                return Err(Error::new("unable to divide by 0"));
             }
             _ => {}
         }
@@ -716,7 +716,7 @@ impl Rem for Number {
                 (IntVariant::Small(i1), IntVariant::Big(i2)) => Ok(Int(IntVariant::Big(i1 % i2))),
                 (IntVariant::Big(i1), IntVariant::Small(i2)) => Ok(Int(IntVariant::Big(i1 % i2))),
             },
-            (_, _) => Err(Error::Message("expected integer".to_string())),
+            (_, _) => Err(Error::new("expected integer")),
         }
     }
 }

--- a/src/types/number.rs
+++ b/src/types/number.rs
@@ -130,10 +130,12 @@ impl Number {
         Err(Error::Message(m))
     }
 
+    /// Create `Number` from `i64`.
     pub fn from_i64(value: i64) -> Self {
         Int(IntVariant::Small(value))
     }
 
+    /// Convert `Number` to `i64`.
     pub fn to_i64(&self) -> Option<i64> {
         match self {
             Int(int_var) => match int_var {
@@ -158,10 +160,12 @@ impl Number {
         }
     }
 
+    /// Create `Number` from `f64`.
     pub fn from_f64(value: f64) -> Self {
         Float(value)
     }
 
+    /// Convert `Number` to `f64`.
     pub fn to_f64(&self) -> Option<f64> {
         match self {
             Int(int_var) => match int_var {
@@ -171,6 +175,18 @@ impl Number {
             Float(f) => Some(*f),
             Rational(r) => r.to_f64(),
             Complex(_) => None,
+        }
+    }
+
+    /// Convert `Number` to `usize`.
+    pub fn to_usize(&self) -> Option<usize> {
+        match self {
+            Int(int_var) => match int_var {
+                IntVariant::Small(i) => Some(*i as usize),
+                IntVariant::Big(b) => b.to_usize(),
+            },
+            Float(f) => Some(*f as usize),
+            _ => None,
         }
     }
 


### PR DESCRIPTION
## Changes made
- Implement `Vector` type.
- Implement all R7RS `Vector` procedures:

Procedures:
- [x] vector?
- [x] vector
- [x] make-vector
- [x] vector-length
- [x] vector-ref
- [x] vector-set!
- [x] vector-fill!
- [x] vector-copy
- [x] vector-append
- [x] vector->list
- [x] vector->string
- [x] list->vector
- [x] string->vector 