### PR TITLE
Implement write, refactor write tests, show datum labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "cfg-if"
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "nix"

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -157,6 +157,7 @@ impl Env {
             env.insert_proc("write-char", procedures::write_char);
             env.insert_proc("write-string", procedures::write_string);
             env.insert_proc("write-u8", procedures::write_u8);
+            env.insert_proc("write", procedures::write);
             env.insert_proc("write-simple", procedures::write_simple);
             env.insert_proc("write-shared", procedures::write_shared);
             env.insert_proc("read-bytevector", procedures::read_bytevector);

--- a/src/env/procedures.rs
+++ b/src/env/procedures.rs
@@ -504,112 +504,144 @@ pub fn cdddr(args: &[Expr], _: EnvRef) -> Result {
 
 pub fn caaaar(args: &[Expr], _: EnvRef) -> Result {
     match args {
-        [Expr::Pair(p)] => p.caaaar().map_err(|_| Error::new("caaaar: not enough pairs")),
+        [Expr::Pair(p)] => p
+            .caaaar()
+            .map_err(|_| Error::new("caaaar: not enough pairs")),
         _ => Err(Error::new("caaaar: expected pair")),
     }
 }
 
 pub fn caaadr(args: &[Expr], _: EnvRef) -> Result {
     match args {
-        [Expr::Pair(p)] => p.caaadr().map_err(|_| Error::new("caaadr: not enough pairs")),
+        [Expr::Pair(p)] => p
+            .caaadr()
+            .map_err(|_| Error::new("caaadr: not enough pairs")),
         _ => Err(Error::new("caaadr: expected pair")),
     }
 }
 
 pub fn caadar(args: &[Expr], _: EnvRef) -> Result {
     match args {
-        [Expr::Pair(p)] => p.caadar().map_err(|_| Error::new("caadar: not enough pairs")),
+        [Expr::Pair(p)] => p
+            .caadar()
+            .map_err(|_| Error::new("caadar: not enough pairs")),
         _ => Err(Error::new("caadar: expected pair")),
     }
 }
 
 pub fn caaddr(args: &[Expr], _: EnvRef) -> Result {
     match args {
-        [Expr::Pair(p)] => p.caaddr().map_err(|_| Error::new("caaddr: not enough pairs")),
+        [Expr::Pair(p)] => p
+            .caaddr()
+            .map_err(|_| Error::new("caaddr: not enough pairs")),
         _ => Err(Error::new("caaddr: expected pair")),
     }
 }
 
 pub fn cadaar(args: &[Expr], _: EnvRef) -> Result {
     match args {
-        [Expr::Pair(p)] => p.cadaar().map_err(|_| Error::new("cadaar: not enough pairs")),
+        [Expr::Pair(p)] => p
+            .cadaar()
+            .map_err(|_| Error::new("cadaar: not enough pairs")),
         _ => Err(Error::new("cadaar: expected pair")),
     }
 }
 
 pub fn cadadr(args: &[Expr], _: EnvRef) -> Result {
     match args {
-        [Expr::Pair(p)] => p.cadadr().map_err(|_| Error::new("cadadr: not enough pairs")),
+        [Expr::Pair(p)] => p
+            .cadadr()
+            .map_err(|_| Error::new("cadadr: not enough pairs")),
         _ => Err(Error::new("cadadr: expected pair")),
     }
 }
 
 pub fn caddar(args: &[Expr], _: EnvRef) -> Result {
     match args {
-        [Expr::Pair(p)] => p.caddar().map_err(|_| Error::new("caddar: not enough pairs")),
+        [Expr::Pair(p)] => p
+            .caddar()
+            .map_err(|_| Error::new("caddar: not enough pairs")),
         _ => Err(Error::new("caddar: expected pair")),
     }
 }
 
 pub fn cadddr(args: &[Expr], _: EnvRef) -> Result {
     match args {
-        [Expr::Pair(p)] => p.cadddr().map_err(|_| Error::new("cadddr: not enough pairs")),
+        [Expr::Pair(p)] => p
+            .cadddr()
+            .map_err(|_| Error::new("cadddr: not enough pairs")),
         _ => Err(Error::new("cadddr: expected pair")),
     }
 }
 
 pub fn cdaaar(args: &[Expr], _: EnvRef) -> Result {
     match args {
-        [Expr::Pair(p)] => p.cdaaar().map_err(|_| Error::new("cdaaar: not enough pairs")),
+        [Expr::Pair(p)] => p
+            .cdaaar()
+            .map_err(|_| Error::new("cdaaar: not enough pairs")),
         _ => Err(Error::new("cdaaar: expected pair")),
     }
 }
 
 pub fn cdaadr(args: &[Expr], _: EnvRef) -> Result {
     match args {
-        [Expr::Pair(p)] => p.cdaadr().map_err(|_| Error::new("cdaadr: not enough pairs")),
+        [Expr::Pair(p)] => p
+            .cdaadr()
+            .map_err(|_| Error::new("cdaadr: not enough pairs")),
         _ => Err(Error::new("cdaadr: expected pair")),
     }
 }
 
 pub fn cdadar(args: &[Expr], _: EnvRef) -> Result {
     match args {
-        [Expr::Pair(p)] => p.cdadar().map_err(|_| Error::new("cdadar: not enough pairs")),
+        [Expr::Pair(p)] => p
+            .cdadar()
+            .map_err(|_| Error::new("cdadar: not enough pairs")),
         _ => Err(Error::new("cdadar: expected pair")),
     }
 }
 
 pub fn cdaddr(args: &[Expr], _: EnvRef) -> Result {
     match args {
-        [Expr::Pair(p)] => p.cdaddr().map_err(|_| Error::new("cdaddr: not enough pairs")),
+        [Expr::Pair(p)] => p
+            .cdaddr()
+            .map_err(|_| Error::new("cdaddr: not enough pairs")),
         _ => Err(Error::new("cdaddr: expected pair")),
     }
 }
 
 pub fn cddaar(args: &[Expr], _: EnvRef) -> Result {
     match args {
-        [Expr::Pair(p)] => p.cddaar().map_err(|_| Error::new("cddaar: not enough pairs")),
+        [Expr::Pair(p)] => p
+            .cddaar()
+            .map_err(|_| Error::new("cddaar: not enough pairs")),
         _ => Err(Error::new("cddaar: expected pair")),
     }
 }
 
 pub fn cddadr(args: &[Expr], _: EnvRef) -> Result {
     match args {
-        [Expr::Pair(p)] => p.cddadr().map_err(|_| Error::new("cddadr: not enough pairs")),
+        [Expr::Pair(p)] => p
+            .cddadr()
+            .map_err(|_| Error::new("cddadr: not enough pairs")),
         _ => Err(Error::new("cddadr: expected pair")),
     }
 }
 
 pub fn cdddar(args: &[Expr], _: EnvRef) -> Result {
     match args {
-        [Expr::Pair(p)] => p.cdddar().map_err(|_| Error::new("cdddar: not enough pairs")),
+        [Expr::Pair(p)] => p
+            .cdddar()
+            .map_err(|_| Error::new("cdddar: not enough pairs")),
         _ => Err(Error::new("cdddar: expected pair")),
     }
 }
 
 pub fn cddddr(args: &[Expr], _: EnvRef) -> Result {
     match args {
-        [Expr::Pair(p)] => p.cddddr().map_err(|_| Error::new("cddddr: not enough pairs")),
+        [Expr::Pair(p)] => p
+            .cddddr()
+            .map_err(|_| Error::new("cddddr: not enough pairs")),
         _ => Err(Error::new("cddddr: expected pair")),
     }
 }
@@ -1609,8 +1641,29 @@ pub fn write_u8(args: &[Expr], env: EnvRef) -> Result {
 
 /// Write arguments to a textual `Port`.
 /// Defaults to `current-output-port` if port is not specified.
+/// Labels cyclic structure with datum labels; non-cyclic shared structure is expanded inline.
 pub fn write(args: &[Expr], env: EnvRef) -> Result {
-    todo!()
+    match args {
+        [expr] => {
+            let port = env
+                .borrow()
+                .find_param("current-output-port")
+                .ok_or_else(|| Error::new("current-output-port is not initialized"))?;
+
+            if let Expr::Port(Port::TextOutput(port)) = port {
+                let mut port = port.borrow_mut();
+                port.write_string(&expr.with_cycle_labels())?;
+                return Ok(Expr::Void());
+            }
+            Err(Error::new("current-output-port is not initialized"))
+        }
+        [expr, Expr::Port(Port::TextOutput(port))] => {
+            let mut port = port.borrow_mut();
+            port.write_string(&expr.with_cycle_labels())?;
+            Ok(Expr::Void())
+        }
+        _ => Err(Error::new("expected obj and optional text output port")),
+    }
 }
 
 /// Write arguments to a textual `Port`.

--- a/src/io.rs
+++ b/src/io.rs
@@ -5,7 +5,7 @@
 //! Functions for REPL IO.
 
 use std::fs::File;
-use std::io::{self, stdout, BufRead, Write};
+use std::io::{self, BufRead, Write, stdout};
 use std::process;
 
 use colored::{self, Colorize};

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use crate::parser::parse_and_eval;
 fn process_line(env: EnvRef) -> ProcessLineFunc {
     Box::new(
         move |line: String| match parse_and_eval(line, env.clone()) {
-            Ok(result) => Ok(result.to_string()),
+            Ok(result) => Ok(result.with_datum_labels()),
             Err(Error::Message(e)) => Err(repl_lib::Error::User(repl_lib::UserError {
                 error: format!("{}", e),
             })),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,7 +7,7 @@
 use crate::env::EnvRef;
 use crate::error::Error;
 use crate::macros::{apply_lambda, define, if_statement, lambda, parameterize, quote, set_car};
-use crate::types::{Expr, Number, Pair, Parameter, BOOLEAN_FALSE_STR, BOOLEAN_TRUE_STR};
+use crate::types::{BOOLEAN_FALSE_STR, BOOLEAN_TRUE_STR, Expr, Number, Pair, Parameter};
 
 /// Parse s-expression, evaluate it, and return result.
 pub fn parse_and_eval(expr: String, env: EnvRef) -> Result<Expr, Error> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -178,7 +178,11 @@ fn test_define_atome() {
 fn test_define_lambda_explicit() {
     use crate::{env::Env, parser::parse_and_eval};
     let env = Env::standard_env();
-    parse_and_eval("(define addone (lambda (x) (+ x 1)))".to_string(), env.clone()).unwrap();
+    parse_and_eval(
+        "(define addone (lambda (x) (+ x 1)))".to_string(),
+        env.clone(),
+    )
+    .unwrap();
     let result = parse_and_eval("(addone 1)".to_string(), env).unwrap();
     assert_eq!(result.to_string(), "2");
 }
@@ -586,9 +590,11 @@ fn test_list_to_string() {
 fn test_list_to_string_with_start() {
     use crate::{env::Env, parser::parse_and_eval};
     let env = Env::standard_env();
-    let result =
-        parse_and_eval("(list->string (list #\\h #\\e #\\l #\\l #\\o) 1)".to_string(), env)
-            .unwrap();
+    let result = parse_and_eval(
+        "(list->string (list #\\h #\\e #\\l #\\l #\\o) 1)".to_string(),
+        env,
+    )
+    .unwrap();
     assert_eq!(result.formatted(), "ello");
 }
 
@@ -596,9 +602,11 @@ fn test_list_to_string_with_start() {
 fn test_list_to_string_with_start_and_end() {
     use crate::{env::Env, parser::parse_and_eval};
     let env = Env::standard_env();
-    let result =
-        parse_and_eval("(list->string (list #\\h #\\e #\\l #\\l #\\o) 1 4)".to_string(), env)
-            .unwrap();
+    let result = parse_and_eval(
+        "(list->string (list #\\h #\\e #\\l #\\l #\\o) 1 4)".to_string(),
+        env,
+    )
+    .unwrap();
     assert_eq!(result.formatted(), "ell");
 }
 
@@ -622,8 +630,7 @@ fn test_list_to_vector_with_start() {
 fn test_list_to_vector_with_start_and_end() {
     use crate::{env::Env, parser::parse_and_eval, types::Expr};
     let env = Env::standard_env();
-    let result =
-        parse_and_eval("(list->vector (list 1 2 3 4 5) 1 4)".to_string(), env).unwrap();
+    let result = parse_and_eval("(list->vector (list 1 2 3 4 5) 1 4)".to_string(), env).unwrap();
     assert!(matches!(result, Expr::Vector(_)));
 }
 
@@ -647,8 +654,7 @@ fn test_vector_to_list_with_start() {
 fn test_vector_to_list_with_start_and_end() {
     use crate::{env::Env, parser::parse_and_eval, types::Expr};
     let env = Env::standard_env();
-    let result =
-        parse_and_eval("(vector->list (vector 1 2 3 4 5) 1 3)".to_string(), env).unwrap();
+    let result = parse_and_eval("(vector->list (vector 1 2 3 4 5) 1 3)".to_string(), env).unwrap();
     assert!(matches!(result, Expr::Pair(_)));
 }
 
@@ -1385,6 +1391,53 @@ fn test_write_shared_cyclic() {
     parse_and_eval("(write-shared x p)".to_string(), env.clone()).unwrap();
     let result = parse_and_eval("(get-output-string p)".to_string(), env).unwrap();
     assert_eq!(result.formatted(), "#0=(1 2 3 . #0#)");
+}
+
+#[test]
+fn test_write_no_sharing() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    parse_and_eval("(define p (open-output-string))".to_string(), env.clone()).unwrap();
+    parse_and_eval("(write '(1 2 3) p)".to_string(), env.clone()).unwrap();
+    let result = parse_and_eval("(get-output-string p)".to_string(), env).unwrap();
+    // No sharing: write and write-shared produce identical output
+    assert_eq!(result.formatted(), "(1 2 3)");
+}
+
+#[test]
+fn test_write_shared_pair_expanded() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    parse_and_eval("(define p (open-output-string))".to_string(), env.clone()).unwrap();
+    parse_and_eval("(define x (list 1 2))".to_string(), env.clone()).unwrap();
+    // write expands non-cyclic shared structure inline — no datum labels
+    parse_and_eval("(write (cons x x) p)".to_string(), env.clone()).unwrap();
+    let result = parse_and_eval("(get-output-string p)".to_string(), env).unwrap();
+    assert_eq!(result.formatted(), "((1 2) 1 2)");
+}
+
+#[test]
+fn test_write_cyclic() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    parse_and_eval("(define p (open-output-string))".to_string(), env.clone()).unwrap();
+    parse_and_eval("(define x (list 1 2 3))".to_string(), env.clone()).unwrap();
+    parse_and_eval("(set-cdr! (cddr x) x)".to_string(), env.clone()).unwrap();
+    // Cyclic structure must use datum labels to avoid infinite output
+    parse_and_eval("(write x p)".to_string(), env.clone()).unwrap();
+    let result = parse_and_eval("(get-output-string p)".to_string(), env).unwrap();
+    assert_eq!(result.formatted(), "#0=(1 2 3 . #0#)");
+}
+
+#[test]
+fn test_write_atoms() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    parse_and_eval("(define p (open-output-string))".to_string(), env.clone()).unwrap();
+    // Atoms: strings get quotes, chars get #\ prefix (external representation)
+    parse_and_eval(r#"(write "hello" p)"#.to_string(), env.clone()).unwrap();
+    let result = parse_and_eval("(get-output-string p)".to_string(), env).unwrap();
+    assert_eq!(result.formatted(), r#""hello""#);
 }
 
 // cxr functions (2-deep)

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -9,7 +9,7 @@ pub mod ports;
 
 use num_integer::div_floor;
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::rc::Rc;
 use std::vec::IntoIter;
@@ -100,85 +100,21 @@ impl Expr {
         }
 
         format_with_labels(self, &mut label_map, &mut 0)
+    }
 
-        // let mut output = String::new();
-        // let mut label_count = 0;
-        //
-        // match self {
-        //     Expr::Pair(p) => {
-        //         output.push('(');
-        //         for node in p.iter() {
-        //             match node {
-        //                 Expr::Pair(node_pair) => {
-        //                     let ptr = node_pair.raw_ptr();
-        //                     // If pair is in datum_map:
-        //                     // - If label is none, set label to #N=
-        //                     // - Else if label is #N=, set to #N#
-        //                     match label_map.get(&ptr) {
-        //                         Some((count, None)) => {
-        //                             let new_label = format!("#{}=", label_count);
-        //                             label_count += 1;
-        //                             label_map.insert(ptr, (*count, Some(new_label.clone())));
-        //                             if !output.is_empty() && &output != "(" {
-        //                                 output.push(' ');
-        //                             }
-        //                             let formatted_pair =
-        //                                 Expr::Pair(Pair::from(node_pair)).to_string();
-        //                             output.push_str(&format!("{}{}", new_label, formatted_pair));
-        //                         }
-        //                         Some(_) => {
-        //                             label_count += 1;
-        //                             if !output.is_empty() && &output != "(" {
-        //                                 output.push(' ');
-        //                             }
-        //                             if node_pair.is_pair() {
-        //                                 output.push_str(". ");
-        //                             }
-        //                             output.push_str(&format!("#{}#", label_count));
-        //                         }
-        //                         None => output.push_str(&format!("{}", Expr::Pair(node_pair))),
-        //                     }
-        //                 }
-        //                 Expr::Vector(node_vec) => {
-        //                     let ptr = node_vec.raw_ptr();
-        //                     match label_map.get(&ptr) {
-        //                         Some((count, None)) => {
-        //                             let new_label = format!("#{}=", label_count);
-        //                             label_count += 1;
-        //                             label_map.insert(ptr, (*count, Some(new_label.clone())));
-        //                             if !output.is_empty() && &output != "(" {
-        //                                 output.push(' ');
-        //                             }
-        //                             let formatted_pair = Expr::Vector(node_vec).to_string();
-        //                             output.push_str(&format!("{}{}", new_label, formatted_pair));
-        //                         }
-        //                         Some(_) => {
-        //                             let new_label = format!("#{}#", label_count);
-        //                             label_count += 1;
-        //                             if !output.is_empty() && &output != "(" {
-        //                                 output.push(' ');
-        //                             }
-        //                             let formatted_pair = Expr::Vector(node_vec).to_string();
-        //                             output.push_str(&format!("{}{}", new_label, formatted_pair));
-        //                         }
-        //                         None => {}
-        //                     }
-        //                 }
-        //                 expr => {
-        //                     if !output.is_empty() && &output != "(" {
-        //                         output.push(' ');
-        //                     }
-        //                     output.push_str(&expr.to_string());
-        //                 }
-        //             }
-        //         }
-        //         output.push(')');
-        //     }
-        //     Expr::Vector(v) => todo!(),
-        //     _ => {}
-        // }
-        //
-        // output
+    pub fn with_cycle_labels(&self) -> String {
+        let mut state_map: HashMap<*const (), State> = HashMap::new();
+        let mut cyclic_set: HashSet<*const ()> = HashSet::new();
+
+        collect_cyclic(self, &mut state_map, &mut cyclic_set);
+
+        // Create map that maps the raw pointer with the (count, label).
+        let mut label_map: HashMap<*const (), (usize, Option<String>)> = HashMap::new();
+        for ptr in cyclic_set.iter() {
+            label_map.insert(*ptr, (1, None));
+        }
+
+        format_with_labels(self, &mut label_map, &mut 0)
     }
 }
 
@@ -234,6 +170,32 @@ fn format_with_labels(
 
             format!("{}{}", prefix, inner)
         }
+        Expr::Vector(v) => {
+            let ptr = v.raw_ptr();
+
+            if let Some((_, Some(label))) = label_map.get(&ptr) {
+                let label_num = label.trim_start_matches('#').trim_end_matches('=');
+                return format!("#{}#", label_num);
+            }
+
+            let prefix = if let Some((count, None)) = label_map.get(&ptr) {
+                let label = format!("#{}=", label_count);
+                let count = *count;
+                *label_count += 1;
+                label_map.insert(ptr, (count, Some(label.clone())));
+                label
+            } else {
+                String::new()
+            };
+
+            let items = v
+                .iter()
+                .map(|elem| format_with_labels(&elem, label_map, label_count))
+                .collect::<Vec<_>>()
+                .join(" ");
+
+            format!("{}#({})", prefix, items)
+        }
         other => other.to_string(),
     }
 }
@@ -280,6 +242,55 @@ fn collect_pairs(expr: &Expr, datum_map: &mut HashMap<*const (), usize>) {
             parse_ptr(datum_map, v.raw_ptr());
             for elem in v.iter() {
                 collect_pairs(&elem, datum_map);
+            }
+        }
+        _ => {}
+    }
+}
+
+enum State {
+    InProgress,
+    Done,
+}
+
+fn collect_cyclic(
+    expr: &Expr,
+    state_map: &mut HashMap<*const (), State>,
+    cyclic_set: &mut HashSet<*const ()>,
+) {
+    match expr {
+        Expr::Pair(p) => {
+            let ptr = p.raw_ptr();
+            match state_map.get(&ptr) {
+                Some(State::InProgress) => {
+                    // Back-edge: this node is on our current call stack
+                    cyclic_set.insert(ptr);
+                }
+                Some(State::Done) => {
+                    // Shared but not cyclic, skip
+                }
+                None => {
+                    state_map.insert(ptr, State::InProgress);
+                    collect_cyclic(&p.car(), state_map, cyclic_set);
+                    collect_cyclic(&p.cdr(), state_map, cyclic_set);
+                    state_map.insert(ptr, State::Done);
+                }
+            }
+        }
+        Expr::Vector(v) => {
+            let ptr = v.raw_ptr();
+            match state_map.get(&ptr) {
+                Some(State::InProgress) => {
+                    cyclic_set.insert(ptr);
+                }
+                Some(State::Done) => {}
+                None => {
+                    state_map.insert(ptr, State::InProgress);
+                    for elem in v.iter() {
+                        collect_cyclic(&elem, state_map, cyclic_set);
+                    }
+                    state_map.insert(ptr, State::Done);
+                }
             }
         }
         _ => {}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -343,7 +343,27 @@ fn format_expr(expr: &Expr, rep: Representation) -> String {
 /// Format string into its literal representation.
 fn format_string(s: &String, rep: Representation) -> String {
     match rep {
-        Representation::External => format!("\"{}\"", s),
+        Representation::External => {
+            let mut out = String::with_capacity(s.len() + 2);
+            out.push('"');
+            for c in s.chars() {
+                match c {
+                    '"' => out.push_str("\\\""),
+                    '\\' => out.push_str("\\\\"),
+                    '\n' => out.push_str("\\n"),
+                    '\r' => out.push_str("\\r"),
+                    '\t' => out.push_str("\\t"),
+                    '\x07' => out.push_str("\\a"),
+                    '\x08' => out.push_str("\\b"),
+                    c if (c as u32) < 0x20 || c == '\x7F' => {
+                        out.push_str(&format!("\\x{:x};", c as u32))
+                    }
+                    c => out.push(c),
+                }
+            }
+            out.push('"');
+            out
+        }
         Representation::Formatted => s.clone(),
     }
 }
@@ -351,7 +371,18 @@ fn format_string(s: &String, rep: Representation) -> String {
 /// Format char into its literal representation.
 fn format_char(c: &char, rep: Representation) -> String {
     match rep {
-        Representation::External => format!("{}{}", "#\\", c),
+        Representation::External => match c {
+            ' ' => "#\\space".to_string(),
+            '\n' => "#\\newline".to_string(),
+            '\t' => "#\\tab".to_string(),
+            '\r' => "#\\return".to_string(),
+            '\0' => "#\\null".to_string(),
+            '\x07' => "#\\alarm".to_string(),
+            '\x08' => "#\\backspace".to_string(),
+            '\x7F' => "#\\delete".to_string(),
+            '\x1B' => "#\\escape".to_string(),
+            c => format!("#\\{}", c),
+        },
         Representation::Formatted => c.to_string(),
     }
 }


### PR DESCRIPTION
## Changes made
- Implement the `write` procedure, with appropriate datum labels.
- Add `write` tests.
- Display cyclic list nodes properly.
- Update `Expr.to_string()` calls with their appropriate formatting (`with_datum_labels`, `with_cyclic_labels`).