### PR TITLE
Allow multiple body statements in define and lambda

### DIFF
--- a/scheme-examples/reverse.scm
+++ b/scheme-examples/reverse.scm
@@ -1,9 +1,8 @@
 ;; Implementing a "reverse" procedure.
 (define (my-reverse ls)
-  (begin
-    (define (my-reverse-inner ls acc)
-      (if (null? ls) acc
-          (my-reverse-inner (cdr ls) (cons (car ls) acc))))
-    (my-reverse-inner ls '())))
+  (define (my-reverse-inner ls acc)
+    (if (null? ls) acc
+        (my-reverse-inner (cdr ls) (cons (car ls) acc))))
+  (my-reverse-inner ls '()))
 
 (my-reverse '(1 2 3))

--- a/src/env/procedures.rs
+++ b/src/env/procedures.rs
@@ -93,7 +93,13 @@ pub fn pretty_print(args: &[Expr], _: EnvRef) -> Result {
     match args.first() {
         Some(Expr::Closure(c)) => {
             let c_args = c.parameters.join(" ");
-            println!("(lambda ({}) {})", c_args, c.body);
+            let c_body = c
+                .body
+                .iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<String>>()
+                .join(" ");
+            println!("(lambda ({}) {})", c_args, c_body);
             return Ok(Expr::Void());
         }
         Some(_) => {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,17 +16,18 @@ pub fn define(args: &[Expr], env: EnvRef) -> Result<Expr, Error> {
             let value = parser::eval(&expr, env.clone())?;
             env.borrow_mut().data.insert(name.to_owned(), value);
         }
-        [Expr::Pair(pair), expr] => {
-            let name = match pair.get(0) {
-                Some(Expr::Symbol(s)) => s,
+        [Expr::Pair(pair), body_expressions @ ..] => {
+            let proc_name = match pair.car() {
+                Expr::Symbol(s) => s,
                 _ => {
                     return Err(Error::new("ill-formed special form name"));
                 }
             };
 
-            let args_without_name = pair.cdr();
-            let value = lambda(&[args_without_name, expr.clone()], env.clone())?;
-            env.borrow_mut().data.insert(name.to_owned(), value);
+            // Lambda parameters (cdr) and body expressions.
+            let lambda_args = [&[pair.cdr()], body_expressions].concat();
+            let value = lambda(&lambda_args, env.clone())?;
+            env.borrow_mut().data.insert(proc_name.to_owned(), value);
         }
         _ => {
             return Err(Error::new("ill-formed special form"));
@@ -50,13 +51,16 @@ pub fn lambda(args: &[Expr], env: EnvRef) -> Result<Expr, Error> {
     // Example:
     // (x y) (+ x y)
     // args  function
+    if args.len() < 2 {
+        return Err(Error::new("ill-formed lambda"));
+    }
 
     let mut iter = args.iter();
 
     // Get argument symbols.
     let arg_list = match iter.next() {
         Some(Expr::Pair(p)) => p,
-        e => return Err(Error::Message(format!("ill-formed lambda: {:?}", e))),
+        _ => return Err(Error::Message(format!("ill-formed lambda"))),
     };
 
     // Add argument symbols to env.
@@ -74,13 +78,8 @@ pub fn lambda(args: &[Expr], env: EnvRef) -> Result<Expr, Error> {
         })
         .collect::<Result<_, _>>()?;
 
-    // Get function.
-    let body = match iter.next() {
-        Some(e) => e,
-        _ => return Err(Error::new("expected lambda body")),
-    };
-
-    let closure = Box::new(Closure::init(env.clone(), params, body.clone()));
+    let body_expressions: Vec<Expr> = args[1..].to_vec();
+    let closure = Box::new(Closure::init(env.clone(), params, body_expressions));
     Ok(Expr::Closure(closure))
 }
 
@@ -102,7 +101,7 @@ pub fn apply_lambda(closure: &Closure, args: Vec<Expr>) -> Result<Expr, Error> {
         }
     }
 
-    parser::eval(&closure.body, new_env)
+    begin(&closure.body, new_env)
 }
 
 /// Process literal into expression.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -197,6 +197,62 @@ fn test_define_lambda_implicit() {
 }
 
 #[test]
+fn test_define_lambda_implicit_multiple_body_expressions() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    parse_and_eval(
+        "(define (do-stuff x) (+ x 1) (+ x 2) (+ x 3))".to_string(),
+        env.clone(),
+    )
+    .unwrap();
+    let result = parse_and_eval("(do-stuff 10)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "13");
+}
+
+#[test]
+fn test_define_lambda_explicit_multiple_body_expressions() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    parse_and_eval(
+        "(define do-stuff (lambda (x) (+ x 1) (+ x 2) (+ x 3)))".to_string(),
+        env.clone(),
+    )
+    .unwrap();
+    let result = parse_and_eval("(do-stuff 10)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "13");
+}
+
+#[test]
+fn test_define_with_internal_define() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    parse_and_eval(
+        "(define (my-reverse ls) \
+           (define (my-reverse-inner ls acc) \
+             (if (null? ls) acc \
+                 (my-reverse-inner (cdr ls) (cons (car ls) acc)))) \
+           (my-reverse-inner ls '()))"
+            .to_string(),
+        env.clone(),
+    )
+    .unwrap();
+    let result = parse_and_eval("(my-reverse '(1 2 3))".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "(3 2 1)");
+}
+
+#[test]
+fn test_lambda_immediate_invocation_multiple_body_expressions() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval(
+        "((lambda (x) (+ x 1) (+ x 2) (* x 10)) 5)".to_string(),
+        env,
+    )
+    .unwrap();
+    assert_eq!(result.to_string(), "50");
+}
+
+#[test]
 fn test_new_list() {
     use crate::{env::Env, parser::parse_and_eval};
     let env = Env::standard_env();

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -482,11 +482,11 @@ pub fn format_port(p: &Port) -> String {
 pub struct Closure {
     pub env: EnvRef,
     pub parameters: Vec<String>,
-    pub body: Expr,
+    pub body: Vec<Expr>,
 }
 
 impl Closure {
-    pub fn init(env: EnvRef, parameters: Vec<String>, body: Expr) -> Closure {
+    pub fn init(env: EnvRef, parameters: Vec<String>, body: Vec<Expr>) -> Closure {
         Closure {
             env,
             parameters,


### PR DESCRIPTION
## Changes made
- Refactor define and lambda to allow multiple body statements
- Refactor closures to contain multiple body statements
- Update `reverse.scm`
- Add more define and lambda unit tests