### PR TITLE
Implement set!

### DIFF
--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -322,6 +322,25 @@ impl Env {
         self.params.insert(param.to_string(), value.clone());
     }
 
+    /// Updates an existing variable in the environment.
+    ///
+    /// Returns `Ok(true)` if the variable exists and was updated.
+    /// Returns `Ok(false)` if the variable does not exist.
+    /// Returns an `Error` if the outer environment cannot be borrowed.
+    pub fn set_expr(&mut self, name: &str, value: &Expr) -> Result<bool, Error> {
+        if self.data.contains_key(name) {
+            self.insert_expr(name, value.clone());
+            Ok(true)
+        } else if let Some(outer) = &self.outer {
+            outer
+                .try_borrow_mut()
+                .map_err(|_| Error::new("unable to borrow runtime environment"))?
+                .set_expr(name, value)
+        } else {
+            Ok(false)
+        }
+    }
+
     /// Initialize default ports:
     /// - current-input-port
     /// - current-output-port

--- a/src/env/procedures.rs
+++ b/src/env/procedures.rs
@@ -80,24 +80,6 @@ pub fn pretty_print(args: &[Expr], _: EnvRef) -> Result {
     }
 }
 
-/// Exit with an exit code.
-/// Defaults to `0` if no exit code is provided.
-///
-/// Returns an error if the status code is not a number,
-/// or can't be converted into an i32 status code.
-pub fn exit(args: &[Expr], _: EnvRef) -> Result {
-    let code = match args {
-        [Expr::Number(n)] => {
-            let msg = format!("unable to convert number to status code: {}", n);
-            n.to_i32().ok_or_else(|| Error::new(&msg))?
-        }
-        [] => 0,
-        _ => return Err(Error::new("expected exit code number or no arguments")),
-    };
-
-    std::process::exit(code);
-}
-
 // Math
 
 /// Add all arguments together.
@@ -2820,4 +2802,24 @@ pub fn make_parameter(args: &[Expr], env: EnvRef) -> Result {
         }
         _ => Err(Error::new("make-parameter: expected 1 or 2 arguments")),
     }
+}
+
+// Misc
+
+/// Exit with an exit code.
+/// Defaults to `0` if no exit code is provided.
+///
+/// Returns an error if the status code is not a number,
+/// or can't be converted into an i32 status code.
+pub fn exit(args: &[Expr], _: EnvRef) -> Result {
+    let code = match args {
+        [Expr::Number(n)] => {
+            let msg = format!("unable to convert number to status code: {}", n);
+            n.to_i32().ok_or_else(|| Error::new(&msg))?
+        }
+        [] => 0,
+        _ => return Err(Error::new("expected exit code number or no arguments")),
+    };
+
+    std::process::exit(code);
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -37,6 +37,26 @@ pub fn define(args: &[Expr], env: EnvRef) -> Result<Expr, Error> {
     Ok(Expr::Void())
 }
 
+/// Assigns a value to an existing variable.
+pub fn set(args: &[Expr], env: EnvRef) -> Result<Expr, Error> {
+    match args {
+        [Expr::Symbol(s), expr] => {
+            let value = parser::eval(expr, env.clone())?;
+
+            let mut borrowed_env = env
+                .try_borrow_mut()
+                .map_err(|_| Error::new("unable to borrow runtime environment"))?;
+
+            if !borrowed_env.set_expr(s, &value)? {
+                return Err(Error::new(&format!("unbound variable: {}", &s)));
+            }
+
+            Ok(Expr::Void())
+        }
+        _ => Err(Error::new("ill-formed special form")),
+    }
+}
+
 /// Bind arguments and evaluate expressions in a locally scoped environment.
 pub fn let_binding(args: &[Expr], env: EnvRef) -> Result<Expr, Error> {
     match args {
@@ -236,7 +256,6 @@ pub fn apply_lambda(closure: &Closure, args: Vec<Expr>) -> Result<Expr, Error> {
         )));
     }
 
-    // new environment extends the closure’s captured env
     let new_env = Env::local_env(closure.env.clone());
 
     {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -46,6 +46,7 @@ pub fn eval(expr: &Expr, env: EnvRef) -> Result<Expr, Error> {
             if let Expr::Symbol(s) = first {
                 match s.as_str() {
                     "define" => return macros::define(args, env),
+                    "set!" => return macros::set(args, env),
                     "begin" => return macros::begin(args, env),
                     "lambda" => return macros::lambda(args, env),
                     "quote" => return macros::quote(args, env),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3263,3 +3263,61 @@ fn test_with_output_to_file_wrong_arg_count() {
     let result = parse_and_eval("(with-output-to-file)".to_string(), env);
     assert!(result.is_err());
 }
+
+// set! mutation
+
+#[test]
+fn test_set_basic() {
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    let env = Env::standard_env();
+    parse_and_eval("(define x 1)".to_string(), env.clone()).unwrap();
+    let void = parse_and_eval("(set! x 42)".to_string(), env.clone()).unwrap();
+    assert!(matches!(void, Expr::Void()));
+    let result = parse_and_eval("x".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "42");
+}
+
+#[test]
+fn test_set_does_not_affect_outer_scope() {
+    use crate::{env::Env, parser::parse_and_eval};
+    // set! mutates the binding where it was defined, not just the local scope.
+    // The outer `x` should be updated because that is where it was bound.
+    let env = Env::standard_env();
+    parse_and_eval("(define x 10)".to_string(), env.clone()).unwrap();
+    parse_and_eval("(set! x 99)".to_string(), env.clone()).unwrap();
+    let result = parse_and_eval("x".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "99");
+}
+
+#[test]
+fn test_set_inside_lambda_mutates_closed_over_binding() {
+    use crate::{env::Env, parser::parse_and_eval};
+    // set! inside a lambda should mutate the binding visible to the lambda.
+    let env = Env::standard_env();
+    parse_and_eval("(define x 0)".to_string(), env.clone()).unwrap();
+    parse_and_eval(
+        "(define (bump!) (set! x (+ x 1)) x)".to_string(),
+        env.clone(),
+    )
+    .unwrap();
+    let _bump1 = parse_and_eval("(bump!)".to_string(), env.clone()).unwrap();
+    let _bump2 = parse_and_eval("(bump!)".to_string(), env.clone()).unwrap();
+    let result = parse_and_eval("x".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "2");
+}
+
+#[test]
+fn test_set_unbound_variable_errors() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(set! undefined-var 1)".to_string(), env);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_set_ill_formed_errors() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(set! x)".to_string(), env);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Changes made
- Implement set!.
- Implement `Env::set_expr()` helper.
- Add corresponding unit tests.
- Move `exit` to bottom of `procedures.rs`