### PR TITLE
R7RS compliance fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "copper"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "colored",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "copper"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 
 [dependencies]

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -73,7 +73,7 @@ impl Env {
             env.insert_proc(">=", procedures::num_greater_or_eq_than);
             // Strings
             env.insert_proc("string", procedures::new_string);
-            env.insert_proc("string-append", procedures::str_append);
+            env.insert_proc("string-append", procedures::string_append);
             env.insert_proc("string-length", procedures::str_length);
             env.insert_proc("string-upcase", procedures::string_to_upcase);
             env.insert_proc("string-downcase", procedures::string_to_downcase);

--- a/src/env/procedures.rs
+++ b/src/env/procedures.rs
@@ -466,13 +466,23 @@ pub fn new_list(args: &[Expr], _: EnvRef) -> Result {
 
 /// Append 2 lists together.
 pub fn list_append(args: &[Expr], _: EnvRef) -> Result {
-    match args {
-        [Expr::Pair(list_a), Expr::Pair(list_b)] if list_a.is_list() && list_b.is_list() => {
-            let result = list_a.clone().append(Expr::Pair(list_b.clone()))?;
-            Ok(result)
+    let mut elements: Vec<Expr> = Vec::new();
+
+    for arg in args {
+        match arg {
+            Expr::Pair(list) if list.is_list() => {
+                let mut list_elem: Vec<Expr> = list.iter().collect();
+                elements.append(&mut list_elem);
+            }
+            _ => return Err(Error::new("expected list")),
         }
-        _ => Err(Error::new("expected 2 lists")),
     }
+
+    if elements.is_empty() {
+        return Ok(Expr::Null);
+    }
+
+    Ok(Pair::list(&elements))
 }
 
 /// Get length of list.

--- a/src/env/procedures.rs
+++ b/src/env/procedures.rs
@@ -368,14 +368,15 @@ pub fn num_greater_or_eq_than(args: &[Expr], _: EnvRef) -> Result {
 // Strings
 
 /// Appends two strings together.
-pub fn str_append(args: &[Expr], _: EnvRef) -> Result {
-    match args {
-        [Expr::String(a), Expr::String(b)] => {
-            let c = a.clone() + b;
-            Ok(Expr::String(c))
+pub fn string_append(args: &[Expr], _: EnvRef) -> Result {
+    let mut result = String::new();
+    for arg in args {
+        match arg {
+            Expr::String(s) => result += s,
+            _ => return Err(Error::new("expected string")),
         }
-        _ => Err(Error::Message(format!("expected 2 strings"))),
     }
+    Ok(Expr::String(result))
 }
 
 /// Returns the size of a string as an `Expr::Number` (more specifically an `IntVariant::Small`).

--- a/src/env/procedures.rs
+++ b/src/env/procedures.rs
@@ -1985,7 +1985,7 @@ pub fn string_to_num(args: &[Expr], _: EnvRef) -> Result {
     match args {
         [Expr::String(num_str)] => match Number::from_token(&num_str) {
             Ok(n) => Ok(Expr::Number(n)),
-            Err(e) => Err(e),
+            Err(_) => Ok(Expr::Boolean(false)),
         },
         _ => Err(Error::new("expected string")),
     }

--- a/src/env/procedures.rs
+++ b/src/env/procedures.rs
@@ -769,6 +769,16 @@ pub fn make_vector(args: &[Expr], _: EnvRef) -> Result {
                 "invalid size, expected int or float".to_string(),
             )),
         },
+        [Expr::Number(n), fill_value] => match n.to_usize() {
+            Some(size) => {
+                let vector = Vector::new();
+                vector.alloc_size(size, Some(fill_value.clone()));
+                Ok(Expr::Vector(vector))
+            }
+            _ => Err(Error::Message(
+                "invalid size, expected int or float".to_string(),
+            )),
+        },
         _ => Ok(Expr::Vector(Vector::new())),
     }
 }

--- a/src/env/procedures.rs
+++ b/src/env/procedures.rs
@@ -387,13 +387,16 @@ pub fn str_length(args: &[Expr], _: EnvRef) -> Result {
     }
 }
 
-/// Create either a new empty string or a string from a char.
+/// Return a newly allocated `Expr::String`, appending all character arguments.
 pub fn new_string(args: &[Expr], _: EnvRef) -> Result {
-    match args {
-        [] => Ok(Expr::String(String::new())),
-        [Expr::Char(c)] => Ok(Expr::String(String::from(*c))),
-        _ => Err(Error::new("expected character")),
+    let mut result = String::new();
+    for arg in args {
+        match arg {
+            Expr::Char(c) => result.push(*c),
+            _ => return Err(Error::new("expected char")),
+        }
     }
+    Ok(Expr::String(result))
 }
 
 /// Convert string to upper case.

--- a/src/env/procedures.rs
+++ b/src/env/procedures.rs
@@ -2600,6 +2600,7 @@ pub fn is_boolean(args: &[Expr], _: EnvRef) -> Result {
 pub fn is_list(args: &[Expr], _: EnvRef) -> Result {
     let result = match args {
         [Expr::Pair(p)] => p.is_list(),
+        [Expr::Null] => true,
         [_] => false,
         _ => {
             return Err(Error::Message(format!(

--- a/src/env/procedures.rs
+++ b/src/env/procedures.rs
@@ -1002,14 +1002,19 @@ pub fn vector_fill(args: &[Expr], _: EnvRef) -> Result {
 
 /// Append two `Vector` and return resulting `Vector`.
 pub fn vector_append(args: &[Expr], _: EnvRef) -> Result {
-    match args {
-        [Expr::Vector(a), Expr::Vector(b)] => {
-            let new_vec = a.deep_copy();
-            new_vec.append(b.deep_copy());
-            Ok(Expr::Vector(new_vec))
+    let elements: Vector = Vector::new();
+
+    for arg in args {
+        match arg {
+            Expr::Vector(v) => {
+                let v_elems: Vector = v.deep_copy();
+                elements.append(v_elems);
+            }
+            _ => return Err(Error::new("expected list")),
         }
-        _ => Err(Error::new("expected 2 vectors")),
     }
+
+    Ok(Expr::Vector(elements))
 }
 
 /// Bytevectors

--- a/src/env/procedures.rs
+++ b/src/env/procedures.rs
@@ -1020,7 +1020,7 @@ pub fn vector_append(args: &[Expr], _: EnvRef) -> Result {
                 let v_elems: Vector = v.deep_copy();
                 elements.append(v_elems);
             }
-            _ => return Err(Error::new("expected list")),
+            _ => return Err(Error::new("expected vector")),
         }
     }
 
@@ -1238,14 +1238,19 @@ pub fn bytevector_copy_from(args: &[Expr], _: EnvRef) -> Result {
 
 /// Return a newly allocated `ByteVector` created from concatenating 2 `ByteVector`.
 pub fn bytevector_append(args: &[Expr], _: EnvRef) -> Result {
-    match args {
-        [Expr::ByteVector(a), Expr::ByteVector(b)] => {
-            let new_slice = [a.to_slice(), b.to_slice()];
-            let bytevector = ByteVector::from(new_slice.concat().as_slice());
-            Ok(Expr::ByteVector(bytevector))
+    let mut elements: Vec<u8> = Vec::new();
+
+    for arg in args {
+        match arg {
+            Expr::ByteVector(bv) => {
+                let mut bv_items: Vec<u8> = bv.deep_copy().iter().collect();
+                elements.append(&mut bv_items);
+            }
+            _ => return Err(Error::new("expected bytevector")),
         }
-        _ => Err(Error::new("expected 2 bytevectors")),
     }
+
+    Ok(Expr::ByteVector(ByteVector::from(&elements)))
 }
 
 // Ports

--- a/src/env/procedures.rs
+++ b/src/env/procedures.rs
@@ -2407,6 +2407,7 @@ pub fn is_complex(args: &[Expr], _: EnvRef) -> Result {
 pub fn is_integer(args: &[Expr], _: EnvRef) -> Result {
     match args {
         [Expr::Number(Number::Int(_))] => Ok(Expr::Boolean(true)),
+        [Expr::Number(Number::Float(f))] if f % 1.0 == 0.0 => Ok(Expr::Boolean(true)),
         [_] => Ok(Expr::Boolean(false)),
         _ => Err(Error::Message(format!(
             "expected 1 argument, got {}",

--- a/src/env/procedures.rs
+++ b/src/env/procedures.rs
@@ -96,7 +96,7 @@ pub fn add(args: &[Expr], _: EnvRef) -> Result {
 pub fn sub(args: &[Expr], _: EnvRef) -> Result {
     let numbers = parser::parse_number_list(args)?;
     if numbers.is_empty() {
-        return Ok(Expr::Number(Number::from_i64(0)));
+        return Err(Error::new("expected at least 1 number"));
     }
 
     let mut iter = numbers.clone().into_iter();
@@ -118,7 +118,7 @@ pub fn sub(args: &[Expr], _: EnvRef) -> Result {
 pub fn mult(args: &[Expr], _: EnvRef) -> Result {
     let numbers = parser::parse_number_list(args)?;
     if numbers.is_empty() {
-        return Err(Error::new("expected at least one number"));
+        return Ok(Expr::Number(Number::from_i64(1)));
     }
     let initial_value: Number = Number::from_i64(1);
     let product = numbers

--- a/src/env/procedures.rs
+++ b/src/env/procedures.rs
@@ -160,14 +160,10 @@ pub fn exponent(args: &[Expr], _: EnvRef) -> Result {
     }
 }
 
-/// Perform modulo to number.
+/// Perform modulo on numbers.
 pub fn modulo(args: &[Expr], _: EnvRef) -> Result {
     match args {
-        [Expr::Number(a), Expr::Number(b)] => {
-            let a = a.clone();
-            let b = b.clone();
-            Ok(Expr::Number((a % b)?))
-        }
+        [Expr::Number(a), Expr::Number(b)] => Ok(Expr::Number(a.clone().modulo(b.clone())?)),
         _ => Err(Error::new("expected 2 numbers")),
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -5,7 +5,7 @@
 //! Define functions and variables.
 
 use crate::env::{Env, EnvRef, try_borrow_env};
-use crate::parser;
+use crate::parser::{self, parse_right_expr};
 use crate::types::{Pair, Vector};
 use crate::{error::Error, types::Closure, types::Expr, types::Parameter};
 use std::rc::Rc;
@@ -370,11 +370,16 @@ fn resolve_unquoted_symbol(symbol: &String, env: EnvRef) -> Result<Expr, Error> 
 pub fn if_statement(args: &[Expr], env: EnvRef) -> Result<Expr, Error> {
     match args {
         [conditional, first_branch, second_branch] => {
-            let cond_result = parser::eval(conditional, env.to_owned())?;
-            match cond_result {
+            match parser::eval(conditional, env.to_owned())? {
                 Expr::Boolean(false) => parser::eval(second_branch, env),
                 _ => parser::eval(first_branch, env),
             }
+        }
+        [conditional, first_branch] => {
+            if let Expr::Boolean(false) = parser::eval(conditional, env.to_owned())? {
+                return Ok(Expr::Void());
+            }
+            parser::eval(first_branch, env)
         }
         _ => Err(Error::new("ill-formed special form")),
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -59,9 +59,9 @@ pub fn set(args: &[Expr], env: EnvRef) -> Result<Expr, Error> {
 
 /// Bind arguments and evaluate expressions in a locally scoped environment.
 pub fn let_binding(args: &[Expr], env: EnvRef) -> Result<Expr, Error> {
-    match args {
+    let binding_env = Env::local_env(env.clone());
+    let body_expressions = match args {
         [Expr::Pair(bindings), body_expressions @ ..] => {
-            let binding_env = Env::local_env(env.clone());
             // Eval bindings in outer env, then insert into new env.
             for binding_pair in bindings.iter() {
                 match binding_pair {
@@ -82,18 +82,22 @@ pub fn let_binding(args: &[Expr], env: EnvRef) -> Result<Expr, Error> {
                 }
             }
 
-            // Eval body
-            for (i, expr) in body_expressions.iter().enumerate() {
-                let value = parser::eval(expr, binding_env.clone())?;
-
-                if i == body_expressions.len() - 1 {
-                    return Ok(value);
-                }
-            }
-            Err(Error::new("missing body expression"))
+            body_expressions
         }
-        _ => Err(Error::new("ill-formed special form")),
+        [Expr::Null, body_expressions @ ..] => body_expressions,
+        _ => return Err(Error::new("ill-formed special form")),
+    };
+
+    // Eval body
+    for (i, expr) in body_expressions.iter().enumerate() {
+        let value = parser::eval(expr, binding_env.clone())?;
+
+        if i == body_expressions.len() - 1 {
+            return Ok(value);
+        }
     }
+
+    Err(Error::new("missing body expression"))
 }
 
 /// Bind arguments and evaluate expressions in a locally scoped environment.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -5,7 +5,7 @@
 //! Define functions and variables.
 
 use crate::env::{Env, EnvRef, try_borrow_env};
-use crate::parser::{self, parse_right_expr};
+use crate::parser;
 use crate::types::{Pair, Vector};
 use crate::{error::Error, types::Closure, types::Expr, types::Parameter};
 use std::rc::Rc;
@@ -385,18 +385,33 @@ pub fn if_statement(args: &[Expr], env: EnvRef) -> Result<Expr, Error> {
     }
 }
 
+/// Evaluate clauses until one is `true`, then evaluate
+/// the clause's corresponding expressions.
+///
+/// Note: `=>` clause syntax is not yet supported.
+///
+/// Example:
+/// ```
+/// (cond
+///   ((string? 10) "this won't be evaluated")
+///   ((number? 10) "this will be evaluated and returned"))
+/// ```
 pub fn cond(args: &[Expr], env: EnvRef) -> Result<Expr, Error> {
-    for arg in args {
+    for (i, arg) in args.iter().enumerate() {
         match arg {
             Expr::Pair(pair) => {
                 let collected_args = pair.iter().collect::<Vec<Expr>>();
                 match collected_args.as_slice() {
-                    [conditional, result] => {
-                        let cond_result = parser::eval(conditional, env.to_owned())?;
-                        if let Expr::Boolean(true) = cond_result {
-                            return parser::eval(result, env);
+                    [Expr::Symbol(s), expr] if s == "else" => {
+                        if i != args.len() - 1 {
+                            return Err(Error::new("else clause must be last condition"));
                         }
+                        return parser::eval(expr, env);
                     }
+                    [conditional, expr] => match parser::eval(conditional, env.to_owned())? {
+                        Expr::Boolean(false) => {}
+                        _ => return parser::eval(expr, env),
+                    },
                     _ => continue,
                 }
             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -23,10 +23,11 @@ fn test_add_string_result() {
 
 #[test]
 fn test_add_number_result() {
-    use crate::{env::Env, parser::parse_and_eval};
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    // Companion to test_add_string_result: assert the result *type* is a number.
     let env = Env::standard_env();
     let result = parse_and_eval("(+ 1 1)".to_string(), env).unwrap();
-    assert_eq!(result.to_string(), "2");
+    assert!(matches!(result, Expr::Number(_)));
 }
 
 #[test]
@@ -39,10 +40,11 @@ fn test_sub_string_result() {
 
 #[test]
 fn test_sub_number_result() {
-    use crate::{env::Env, parser::parse_and_eval};
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    // Companion to test_sub_string_result: assert the result *type* is a number.
     let env = Env::standard_env();
     let result = parse_and_eval("(- 1 1)".to_string(), env).unwrap();
-    assert_eq!(result.to_string(), "0");
+    assert!(matches!(result, Expr::Number(_)));
 }
 
 #[test]
@@ -55,10 +57,11 @@ fn test_mult_string_result() {
 
 #[test]
 fn test_mult_number_result() {
-    use crate::{env::Env, parser::parse_and_eval};
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    // Companion to test_mult_string_result: assert the result *type* is a number.
     let env = Env::standard_env();
     let result = parse_and_eval("(* 1 2)".to_string(), env).unwrap();
-    assert_eq!(result.to_string(), "2");
+    assert!(matches!(result, Expr::Number(_)));
 }
 
 #[test]
@@ -71,10 +74,11 @@ fn test_div_string_result() {
 
 #[test]
 fn test_div_number_result() {
-    use crate::{env::Env, parser::parse_and_eval};
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    // Companion to test_div_string_result: assert the result *type* is a number.
     let env = Env::standard_env();
     let result = parse_and_eval("(/ 4 2)".to_string(), env).unwrap();
-    assert_eq!(result.to_string(), "2");
+    assert!(matches!(result, Expr::Number(_)));
 }
 
 #[test]
@@ -87,10 +91,11 @@ fn test_multiline_nested_string_result() {
 
 #[test]
 fn test_multiline_nested_number_result() {
-    use crate::{env::Env, parser::parse_and_eval};
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    // Companion to test_multiline_nested_string_result: assert the result *type* is a number.
     let env = Env::standard_env();
     let result = parse_and_eval("(+ 1\n  (* 2\n     2)\n)".to_string(), env).unwrap();
-    assert_eq!(result.to_string(), "5");
+    assert!(matches!(result, Expr::Number(_)));
 }
 
 #[test]
@@ -103,10 +108,11 @@ fn test_expt_string_result() {
 
 #[test]
 fn test_expt_number_result() {
-    use crate::{env::Env, parser::parse_and_eval};
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    // Companion to test_expt_string_result: assert the result *type* is a number.
     let env = Env::standard_env();
     let result = parse_and_eval("(expt 2 3)".to_string(), env).unwrap();
-    assert_eq!(result.to_string(), "8");
+    assert!(matches!(result, Expr::Number(_)));
 }
 
 #[test]
@@ -119,10 +125,11 @@ fn test_expt_zero_exponent_string_result() {
 
 #[test]
 fn test_expt_zero_exponent_number_result() {
-    use crate::{env::Env, parser::parse_and_eval};
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    // Companion to test_expt_zero_exponent_string_result: assert the result *type* is a number.
     let env = Env::standard_env();
     let result = parse_and_eval("(expt 5 0)".to_string(), env).unwrap();
-    assert_eq!(result.to_string(), "1");
+    assert!(matches!(result, Expr::Number(_)));
 }
 
 #[test]
@@ -135,10 +142,11 @@ fn test_expt_rational_base_string_result() {
 
 #[test]
 fn test_expt_rational_base_number_result() {
-    use crate::{env::Env, parser::parse_and_eval};
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    // Companion to test_expt_rational_base_string_result: assert the result *type* is a number.
     let env = Env::standard_env();
     let result = parse_and_eval("(expt 1/2 2)".to_string(), env).unwrap();
-    assert_eq!(result.to_string(), "1/4");
+    assert!(matches!(result, Expr::Number(_)));
 }
 
 #[test]
@@ -151,10 +159,11 @@ fn test_expt_nested_string_result() {
 
 #[test]
 fn test_expt_nested_number_result() {
-    use crate::{env::Env, parser::parse_and_eval};
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    // Companion to test_expt_nested_string_result: assert the result *type* is a number.
     let env = Env::standard_env();
     let result = parse_and_eval("(expt 2 (+ 1 2))".to_string(), env).unwrap();
-    assert_eq!(result.to_string(), "8");
+    assert!(matches!(result, Expr::Number(_)));
 }
 
 #[test]
@@ -331,13 +340,11 @@ fn test_let_ill_formed_binding_errors() {
 #[test]
 fn test_let_empty_bindings() {
     use crate::{env::Env, parser::parse_and_eval};
-    // (let () body) with no bindings is valid — body runs in an empty local scope
-    // Note: empty bindings `()` parse as Expr::Null, which is not matched by the Pair arm.
-    // This tests the current implementation behaviour.
+    // R7RS §4.2.2: (let () body) is valid — body runs in an empty local scope and
+    // yields the body's value.
     let env = Env::standard_env();
-    let result = parse_and_eval("(let () (+ 1 2))".to_string(), env);
-    // Either succeeds with 3, or errors; either way it should not panic.
-    let _ = result;
+    let result = parse_and_eval("(let () (+ 1 2))".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "3");
 }
 
 // Let* bindings
@@ -697,11 +704,13 @@ fn test_letrec_star_mutual_recursion() {
 }
 
 #[test]
-fn test_letrec_star_forward_reference_undefined() {
+fn test_letrec_star_forward_reference_is_copper_specific() {
     use crate::{env::Env, parser::parse_and_eval, types::Expr};
-    // Forward references in letrec* are undefined behaviour (R7RS says "it is an error").
-    // The implementation pre-allocates all names as Null, so a forward reference resolves
-    // to Null rather than producing an error.
+    // NOTE: this is NOT a spec conformance test. R7RS §4.2.2 says referencing a
+    // letrec* binding before its value has been assigned "is an error" — i.e. the
+    // behaviour is unspecified, so the spec mandates no particular result. This test
+    // documents copper's specific choice: names are pre-allocated as Null, so a
+    // forward reference resolves to Null instead of signalling an error.
     let env = Env::standard_env();
     let result = parse_and_eval("(letrec* ((y x) (x 1)) y)".to_string(), env).unwrap();
     assert!(matches!(result, Expr::Null));
@@ -782,10 +791,11 @@ fn test_abs_positive_number_string_result() {
 
 #[test]
 fn test_abs_positive_number_result() {
-    use crate::{env::Env, parser::parse_and_eval};
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    // Companion to the string-result test: assert the result *type* is a number.
     let env = Env::standard_env();
     let result = parse_and_eval("(abs 5)".to_string(), env).unwrap();
-    assert_eq!(result.to_string(), "5");
+    assert!(matches!(result, Expr::Number(_)));
 }
 
 #[test]
@@ -798,10 +808,11 @@ fn test_abs_negative_number_string_result() {
 
 #[test]
 fn test_abs_negative_number_result() {
-    use crate::{env::Env, parser::parse_and_eval};
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    // Companion to the string-result test: assert the result *type* is a number.
     let env = Env::standard_env();
     let result = parse_and_eval("(abs -7)".to_string(), env).unwrap();
-    assert_eq!(result.to_string(), "7");
+    assert!(matches!(result, Expr::Number(_)));
 }
 
 #[test]
@@ -814,10 +825,11 @@ fn test_abs_zero_string_result() {
 
 #[test]
 fn test_abs_zero_result() {
-    use crate::{env::Env, parser::parse_and_eval};
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    // Companion to the string-result test: assert the result *type* is a number.
     let env = Env::standard_env();
     let result = parse_and_eval("(abs 0)".to_string(), env).unwrap();
-    assert_eq!(result.to_string(), "0");
+    assert!(matches!(result, Expr::Number(_)));
 }
 
 #[test]
@@ -830,10 +842,11 @@ fn test_abs_rational_string_result() {
 
 #[test]
 fn test_abs_rational_result() {
-    use crate::{env::Env, parser::parse_and_eval};
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    // Companion to the string-result test: assert the result *type* is a number.
     let env = Env::standard_env();
     let result = parse_and_eval("(abs -3/4)".to_string(), env).unwrap();
-    assert_eq!(result.to_string(), "3/4");
+    assert!(matches!(result, Expr::Number(_)));
 }
 
 // I/O Functions
@@ -891,17 +904,21 @@ fn test_modulo() {
 #[test]
 fn test_ceil() {
     use crate::{env::Env, parser::parse_and_eval};
+    // R7RS §6.2.6: ceiling of an inexact argument is inexact, so the external
+    // representation carries a decimal point: 4.0, not 4.
     let env = Env::standard_env();
     let result = parse_and_eval("(ceiling 3.2)".to_string(), env).unwrap();
-    assert_eq!(result.to_string(), "4");
+    assert_eq!(result.to_string(), "4.0");
 }
 
 #[test]
 fn test_floor() {
     use crate::{env::Env, parser::parse_and_eval};
+    // R7RS §6.2.6: floor of an inexact argument is inexact, so the external
+    // representation carries a decimal point: 3.0, not 3.
     let env = Env::standard_env();
     let result = parse_and_eval("(floor 3.8)".to_string(), env).unwrap();
-    assert_eq!(result.to_string(), "3");
+    assert_eq!(result.to_string(), "3.0");
 }
 
 #[test]
@@ -930,8 +947,11 @@ fn test_string_length() {
     assert_eq!(result.to_string(), "5");
 }
 
+// `string` procedure (R7RS §6.7): (string char ...) builds a string from its chars.
+// These previously carried `make_string` names but never exercised `make-string`.
+
 #[test]
-fn test_make_string_empty() {
+fn test_string_proc_empty() {
     use crate::{env::Env, parser::parse_and_eval};
     let env = Env::standard_env();
     let result = parse_and_eval("(string)".to_string(), env).unwrap();
@@ -939,11 +959,20 @@ fn test_make_string_empty() {
 }
 
 #[test]
-fn test_make_string_from_char() {
+fn test_string_proc_from_char() {
     use crate::{env::Env, parser::parse_and_eval};
     let env = Env::standard_env();
     let result = parse_and_eval("(string #\\a)".to_string(), env).unwrap();
     assert_eq!(result.formatted(), "a");
+}
+
+#[test]
+fn test_string_proc_multiple_chars() {
+    use crate::{env::Env, parser::parse_and_eval};
+    // (string #\a #\b #\c) ⇒ "abc"
+    let env = Env::standard_env();
+    let result = parse_and_eval("(string #\\a #\\b #\\c)".to_string(), env).unwrap();
+    assert_eq!(result.formatted(), "abc");
 }
 
 // Boolean Functions
@@ -1144,10 +1173,11 @@ fn test_string_to_list_empty() {
 
 #[test]
 fn test_string_to_vector() {
-    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    use crate::{env::Env, parser::parse_and_eval};
+    // R7RS §6.7: (string->vector "abc") ⇒ a vector of the string's chars.
     let env = Env::standard_env();
     let result = parse_and_eval("(string->vector \"abc\")".to_string(), env).unwrap();
-    assert!(matches!(result, Expr::Vector(_)));
+    assert_eq!(result.to_string(), "#(#\\a #\\b #\\c)");
 }
 
 #[test]
@@ -1158,76 +1188,44 @@ fn test_list_to_string() {
     assert_eq!(result.formatted(), "hi");
 }
 
-#[test]
-fn test_list_to_string_with_start() {
-    use crate::{env::Env, parser::parse_and_eval};
-    let env = Env::standard_env();
-    let result = parse_and_eval(
-        "(list->string (list #\\h #\\e #\\l #\\l #\\o) 1)".to_string(),
-        env,
-    )
-    .unwrap();
-    assert_eq!(result.formatted(), "ello");
-}
-
-#[test]
-fn test_list_to_string_with_start_and_end() {
-    use crate::{env::Env, parser::parse_and_eval};
-    let env = Env::standard_env();
-    let result = parse_and_eval(
-        "(list->string (list #\\h #\\e #\\l #\\l #\\o) 1 4)".to_string(),
-        env,
-    )
-    .unwrap();
-    assert_eq!(result.formatted(), "ell");
-}
+// NOTE: R7RS §6.7/§6.8 define list->string and list->vector with a *single* list
+// argument — they take no start/end. Copper's start/end variants are non-standard, so
+// the tests for them were removed (see docs/test-audit.md, "Blocked / flagged").
 
 #[test]
 fn test_list_to_vector() {
-    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    use crate::{env::Env, parser::parse_and_eval};
+    // R7RS §6.8: (list->vector (list 1 2 3)) ⇒ #(1 2 3).
     let env = Env::standard_env();
     let result = parse_and_eval("(list->vector (list 1 2 3))".to_string(), env).unwrap();
-    assert!(matches!(result, Expr::Vector(_)));
-}
-
-#[test]
-fn test_list_to_vector_with_start() {
-    use crate::{env::Env, parser::parse_and_eval, types::Expr};
-    let env = Env::standard_env();
-    let result = parse_and_eval("(list->vector (list 1 2 3 4) 1)".to_string(), env).unwrap();
-    assert!(matches!(result, Expr::Pair(_) | Expr::Vector(_)));
-}
-
-#[test]
-fn test_list_to_vector_with_start_and_end() {
-    use crate::{env::Env, parser::parse_and_eval, types::Expr};
-    let env = Env::standard_env();
-    let result = parse_and_eval("(list->vector (list 1 2 3 4 5) 1 4)".to_string(), env).unwrap();
-    assert!(matches!(result, Expr::Vector(_)));
+    assert_eq!(result.to_string(), "#(1 2 3)");
 }
 
 #[test]
 fn test_vector_to_list() {
-    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    use crate::{env::Env, parser::parse_and_eval};
+    // R7RS §6.8: (vector->list (vector 1 2 3)) ⇒ (1 2 3).
     let env = Env::standard_env();
     let result = parse_and_eval("(vector->list (vector 1 2 3))".to_string(), env).unwrap();
-    assert!(matches!(result, Expr::Pair(_)));
+    assert_eq!(result.to_string(), "(1 2 3)");
 }
 
 #[test]
 fn test_vector_to_list_with_start() {
-    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    use crate::{env::Env, parser::parse_and_eval};
+    // R7RS §6.8: vector->list takes an optional start; (vector->list #(1 2 3 4) 2) ⇒ (3 4).
     let env = Env::standard_env();
     let result = parse_and_eval("(vector->list (vector 1 2 3 4) 2)".to_string(), env).unwrap();
-    assert!(matches!(result, Expr::Pair(_)));
+    assert_eq!(result.to_string(), "(3 4)");
 }
 
 #[test]
 fn test_vector_to_list_with_start_and_end() {
-    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    use crate::{env::Env, parser::parse_and_eval};
+    // R7RS §6.8: (vector->list #(1 2 3 4 5) 1 3) ⇒ (2 3).
     let env = Env::standard_env();
     let result = parse_and_eval("(vector->list (vector 1 2 3 4 5) 1 3)".to_string(), env).unwrap();
-    assert!(matches!(result, Expr::Pair(_)));
+    assert_eq!(result.to_string(), "(2 3)");
 }
 
 #[test]
@@ -3958,4 +3956,429 @@ fn test_boolean_eq_three_mixed() {
     let env = Env::standard_env();
     let result = parse_and_eval("(boolean=? #t #t #f)".to_string(), env).unwrap();
     assert_eq!(result.to_string(), "#f");
+}
+
+// ============================================================================
+// Category B — missing R7RS coverage (see docs/test-audit.md).
+// Written to the spec; some fail against the current implementation and stand
+// as executable spec targets (tracked under "Expected red tests").
+// ============================================================================
+
+// --- if (R7RS §4.1.5) ---
+
+#[test]
+fn test_if_true_branch() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(if #t 1 2)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "1");
+}
+
+#[test]
+fn test_if_false_branch() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(if #f 1 2)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "2");
+}
+
+#[test]
+fn test_if_truthy_non_boolean() {
+    // Any value other than #f is true, so 0 selects the consequent.
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(if 0 'yes 'no)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "yes");
+}
+
+#[test]
+fn test_if_one_armed_true() {
+    // R7RS §4.1.5: (if <test> <consequent>) is valid; a true test yields the consequent.
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(if #t 'yes)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "yes");
+}
+
+// --- cond (R7RS §4.2.1) ---
+
+#[test]
+fn test_cond_first_match() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(cond (#t 1) (#t 2))".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "1");
+}
+
+#[test]
+fn test_cond_later_match() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(cond (#f 1) (#t 2))".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "2");
+}
+
+#[test]
+fn test_cond_computed_test() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(cond ((> 3 2) 'yes))".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "yes");
+}
+
+#[test]
+fn test_cond_truthy_non_boolean() {
+    // A clause test of any non-#f value selects the clause; 1 is true.
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(cond (1 'yes))".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "yes");
+}
+
+#[test]
+fn test_cond_else_clause() {
+    // R7RS §4.2.1: else is the catch-all when no earlier test is true.
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(cond (#f 1) (else 2))".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "2");
+}
+
+// --- begin (R7RS §4.2.3) ---
+
+#[test]
+fn test_begin_returns_last() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(begin 1 2 3)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "3");
+}
+
+#[test]
+fn test_begin_sequences_side_effects() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    parse_and_eval("(define x 0)".to_string(), env.clone()).unwrap();
+    parse_and_eval("(begin (set! x 10) (set! x (+ x 5)))".to_string(), env.clone()).unwrap();
+    let result = parse_and_eval("x".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "15");
+}
+
+// --- arithmetic identity / arity (R7RS §6.2.6) ---
+
+#[test]
+fn test_add_identity() {
+    // (+) ⇒ 0 (additive identity).
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(+)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "0");
+}
+
+#[test]
+fn test_mult_identity() {
+    // (*) ⇒ 1 (multiplicative identity).
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(*)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "1");
+}
+
+#[test]
+fn test_sub_unary_negation() {
+    // (- z) ⇒ negation.
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(- 5)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "-5");
+}
+
+#[test]
+fn test_div_unary_reciprocal() {
+    // (/ z) ⇒ reciprocal.
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(/ 2)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "1/2");
+}
+
+#[test]
+fn test_sub_no_args_errors() {
+    // R7RS: (-) requires at least one argument; zero args is an error.
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(-)".to_string(), env);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_div_no_args_errors() {
+    // R7RS: (/) requires at least one argument; zero args is an error.
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(/)".to_string(), env);
+    assert!(result.is_err());
+}
+
+// --- variadic ops with identity elements ---
+
+#[test]
+fn test_string_append_empty() {
+    // R7RS §6.7: (string-append) ⇒ "".
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(string-append)".to_string(), env).unwrap();
+    assert_eq!(result.formatted(), "");
+}
+
+#[test]
+fn test_string_append_three() {
+    // string-append is variadic.
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(string-append \"a\" \"b\" \"c\")".to_string(), env).unwrap();
+    assert_eq!(result.formatted(), "abc");
+}
+
+#[test]
+fn test_append_empty() {
+    // R7RS §6.4: (append) ⇒ ().
+    use crate::{env::Env, parser::parse_and_eval, types::Expr};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(append)".to_string(), env).unwrap();
+    assert!(matches!(result, Expr::Null));
+}
+
+#[test]
+fn test_append_three_lists() {
+    // append is variadic.
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(append (list 1) (list 2) (list 3))".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "(1 2 3)");
+}
+
+#[test]
+fn test_vector_append_empty() {
+    // R7RS §6.8: (vector-append) ⇒ #().
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(vector-append)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "#()");
+}
+
+#[test]
+fn test_bytevector_append_empty() {
+    // R7RS §6.9: (bytevector-append) ⇒ #u8().
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(bytevector-append)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "#u8()");
+}
+
+// --- min / max (R7RS §6.2.6) ---
+
+#[test]
+fn test_max_inexact_result() {
+    // When the maximum is inexact, the result is inexact: prints 4.0, not 4.
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(max 3 4.0)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "4.0");
+}
+
+#[test]
+fn test_min_single_arg() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(min 5)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "5");
+}
+
+#[test]
+fn test_max_no_args_errors() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(max)".to_string(), env);
+    assert!(result.is_err());
+}
+
+// --- modulo sign semantics (R7RS §6.2.6: result takes the sign of the divisor) ---
+
+#[test]
+fn test_modulo_negative_dividend() {
+    // (modulo -7 3) ⇒ 2 (sign follows the divisor, unlike remainder).
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(modulo -7 3)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "2");
+}
+
+#[test]
+fn test_modulo_negative_divisor() {
+    // (modulo 7 -3) ⇒ -2.
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(modulo 7 -3)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "-2");
+}
+
+// --- predicate negatives & numeric tower (R7RS §6.2, §6.3) ---
+
+#[test]
+fn test_integer_predicate_on_float() {
+    // 3.0 is an integer (an integer-valued real).
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(integer? 3.0)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "#t");
+}
+
+#[test]
+fn test_list_predicate_improper() {
+    // An improper (dotted) pair is not a list.
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(list? (cons 1 2))".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "#f");
+}
+
+#[test]
+fn test_list_predicate_empty() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(list? '())".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "#t");
+}
+
+#[test]
+fn test_pair_predicate_empty_list() {
+    // (pair? '()) ⇒ #f.
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(pair? '())".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "#f");
+}
+
+#[test]
+fn test_char_alphabetic_false() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(char-alphabetic? #\\5)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "#f");
+}
+
+#[test]
+fn test_symbol_predicate_false() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(symbol? 42)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "#f");
+}
+
+#[test]
+fn test_string_predicate_false() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(string? 42)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "#f");
+}
+
+#[test]
+fn test_number_predicate_false() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(number? \"x\")".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "#f");
+}
+
+#[test]
+fn test_procedure_predicate_false() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(procedure? 42)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "#f");
+}
+
+// --- conversion edge cases (R7RS §6.2.6) ---
+
+#[test]
+fn test_string_to_number_failure_returns_false() {
+    // R7RS: string->number returns #f when the string is not a number — it must not error.
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(string->number \"abc\")".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "#f");
+}
+
+// --- vector operations, direct (R7RS §6.8) ---
+
+#[test]
+fn test_vector_ref_direct() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(vector-ref (vector 10 20 30) 1)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "20");
+}
+
+#[test]
+fn test_vector_set_mutates() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    parse_and_eval("(define v (vector 1 2 3))".to_string(), env.clone()).unwrap();
+    parse_and_eval("(vector-set! v 0 99)".to_string(), env.clone()).unwrap();
+    let result = parse_and_eval("v".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "#(99 2 3)");
+}
+
+#[test]
+fn test_vector_length_direct() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(vector-length (vector 1 2 3))".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "3");
+}
+
+#[test]
+fn test_make_vector_with_fill() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(make-vector 3 0)".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "#(0 0 0)");
+}
+
+#[test]
+fn test_vector_fill_mutates() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    parse_and_eval("(define v (vector 1 2 3))".to_string(), env.clone()).unwrap();
+    parse_and_eval("(vector-fill! v 7)".to_string(), env.clone()).unwrap();
+    let result = parse_and_eval("v".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "#(7 7 7)");
+}
+
+#[test]
+fn test_vector_copy_direct() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(vector-copy (vector 1 2 3))".to_string(), env).unwrap();
+    assert_eq!(result.to_string(), "#(1 2 3)");
+}
+
+// --- string operations, direct (R7RS §6.7) ---
+
+#[test]
+fn test_string_upcase_direct() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(string-upcase \"abc\")".to_string(), env).unwrap();
+    assert_eq!(result.formatted(), "ABC");
+}
+
+#[test]
+fn test_string_downcase_direct() {
+    use crate::{env::Env, parser::parse_and_eval};
+    let env = Env::standard_env();
+    let result = parse_and_eval("(string-downcase \"ABC\")".to_string(), env).unwrap();
+    assert_eq!(result.formatted(), "abc");
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1214,6 +1214,12 @@ impl ByteVector {
         Ok(end_index - start_index)
     }
 
+    /// Return a deep copy of `&self.elements`.
+    pub fn deep_copy(&self) -> ByteVector {
+        let copied_elements: Vec<u8> = self.buffer.borrow().iter().map(|e| e.clone()).collect();
+        ByteVector::from(&copied_elements)
+    }
+
     /// Return size of `buffer`.
     pub fn len(&self) -> usize {
         self.buffer.borrow().len()

--- a/src/types/number.rs
+++ b/src/types/number.rs
@@ -756,7 +756,12 @@ impl fmt::Display for Number {
             Int(IntVariant::Small(i)) => write!(f, "{}", i),
             Int(IntVariant::Big(b)) => write!(f, "{}", b),
             Rational(r) => write!(f, "{}", r),
-            Float(r) => write!(f, "{}", r),
+            Float(fl) => {
+                if fl.rem(1.0) == 0.0 {
+                    return write!(f, "{:.1}", fl);
+                };
+                write!(f, "{}", fl)
+            }
             Complex(c) => write!(f, "{}", c),
         }
     }

--- a/src/types/number.rs
+++ b/src/types/number.rs
@@ -372,6 +372,23 @@ impl Number {
             None => false,
         }
     }
+
+    /// Perform modulo with another `Number`.
+    ///
+    /// Note: the result takes the sign of the divisor.
+    pub fn modulo(self, divisor: Number) -> Result<Number, Error> {
+        let remainder = (self % divisor.clone())?;
+        let shifted = (remainder + divisor.clone())?;
+        let mut result = (shifted % divisor.clone())?;
+
+        // Make sure the result takes the sign of the divisor.
+        let zero = Number::from_i64(0);
+        if (divisor < zero && result > zero) || (divisor > zero && result < zero) {
+            result = (result * Number::from_i64(-1))?;
+        }
+
+        Ok(result)
+    }
 }
 
 impl Add for Number {


### PR DESCRIPTION
## Changes made
1. Updated the test suite to more accurately follow the R7RS spec.
2. Fixed the following failing tests (R7RS compliance issues):
  - `test_let_empty_bindings` — `(let () …)` not handled.
  - `test_if_one_armed_true` — `if` requires exactly 3 forms.
  - `test_cond_truthy_non_boolean` — `cond` selects only on `#t`, not any non-`#f`.
  - `test_cond_else_clause` — `else` evaluated as an unbound variable.
  - `test_floor`, `test_ceil` — expect `3.0`/`4.0`; printer drops `.0`.
  - `test_max_inexact_result` — expects `4.0`; printer drops `.0`.
  - `test_mult_identity` — `(*)` errors; should be `1`.
  - `test_sub_no_args_errors` — `(-)` returns `0`; should error.
  - `test_modulo_negative_dividend`, `test_modulo_negative_divisor` — `modulo` is truncated remainder.
  - `test_integer_predicate_on_float` — `(integer? 3.0)` ⇒ `#f`; should be `#t`.
  - `test_string_append_empty`, `test_string_append_three` — `string-append` arity-2 only.
  - `test_string_proc_multiple_chars` — `string` not variadic.
  - `test_append_empty`, `test_append_three_lists` — `append` arity-2 only.
  - `test_vector_append_empty`, `test_bytevector_append_empty` — arity-2 only.
  - `test_list_predicate_empty` — `(list? '())` ⇒ `#f`; should be `#t`.
  - `test_make_vector_with_fill` — `(make-vector 3 0)` ⇒ `#()`; should be `#(0 0 0)`.
  - `test_string_to_number_failure_returns_false` — errors instead of returning `#f`.
